### PR TITLE
Fix goroutine leak for helm proxy

### DIFF
--- a/pkg/sghelm/proxy/tunnel.go
+++ b/pkg/sghelm/proxy/tunnel.go
@@ -79,7 +79,7 @@ func (t *tunnel) forwardPort() error {
 		return err
 	}
 
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		errChan <- pf.ForwardPorts()
 	}()


### PR DESCRIPTION
Proxy portforwarder keeps connection to kube-apiserver open even if it is closed.


Related to https://github.com/supergiant/control/issues/916 (reduces number of connections)