### PR TITLE
Multi-AZ cluster

### DIFF
--- a/pkg/workflows/steps/amazon/create_subnet.go
+++ b/pkg/workflows/steps/amazon/create_subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
@@ -69,6 +70,7 @@ func (s *CreateSubnetStep) Run(ctx context.Context, w io.Writer, cfg *steps.Conf
 		if len(out.Subnets) == 0 {
 			return errors.Wrap(ErrCreateSubnet, "no default subnet found")
 		}
+		logrus.Debugf("Take subnet %s", *out.Subnets[0].SubnetId)
 		cfg.AWSConfig.SubnetID = *out.Subnets[0].SubnetId
 	} else {
 		log.Infof("[%s] - using subnet %s", s.Name(), cfg.AWSConfig.SubnetID)

--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -101,11 +101,11 @@ func Init() {
 	awsPreProvision := []steps.Step{
 		steps.GetStep(amazon.StepCreateVPC),
 		steps.GetStep(amazon.StepCreateSecurityGroups),
-		steps.GetStep(amazon.StepCreateSubnet),
 		steps.GetStep(amazon.StepImportKeyPair),
 	}
 
 	awsMasterWorkflow := []steps.Step{
+		steps.GetStep(amazon.StepCreateSubnet),
 		steps.GetStep(amazon.StepNameCreateEC2Instance),
 		steps.GetStep(ssh.StepName),
 		steps.GetStep(authorizedKeys.StepName),
@@ -122,6 +122,7 @@ func Init() {
 	}
 
 	awsNodeWorkflow := []steps.Step{
+		steps.GetStep(amazon.StepCreateSubnet),
 		steps.GetStep(amazon.StepNameCreateEC2Instance),
 		steps.GetStep(ssh.StepName),
 		steps.GetStep(authorizedKeys.StepName),


### PR DESCRIPTION
Enable multiple AZ cluster deployment for AWS
By default AWS creates subnet in each AZ for VPC
region. We can use those subnets for creating instances
in different availability zones and employ them to have
highly-available AWS cluster.

API Changes

Now availability zone parameter goes in node profile object

```
{
    "clusterName": "gleb",
    "profile": {
        "masterProfiles": [{
            "size": "m4.large",
            "volumeSize": "80",
            "ebsOptimized": "true",
            "hasPublicAddr": "true",

           // New field
            "availabilityZone": "eu-west-1a"
        }],
        "nodesProfiles": [{
            "size": "m4.large",
            "volumeSize": "80",
            "ebsOptimized": "true",
            "hasPublicAddr": "true",

           // New field
            "availabilityZone": "eu-west-1b"
            },
            {
            "size": "m4.large",
            "volumeSize": "80",
            "ebsOptimized": "true",
            "hasPublicAddr": "true",

             // New field
            "availabilityZone": "eu-west-1c"
            }
        ],
        "provider": "aws",
        "region": "eu-west-1",
        "arch": "amd64",
        "operatingSystem": "linux",
        "ubuntuVersion": "xenial",
        "dockerVersion": "17.06.0",
        "K8SVersion": "1.11.1",
        "flannelVersion": "0.10.0",
        "networkType": "vxlan",
        "cidr": "10.2.0.0/16",
        "helmVersion": "2.8.0",
        "rbacEnabled": true,
         "publicKey": "",
        "cloudSpecificSettings": {
            "aws_vpc_cidr": "10.2.0.0/16",
            "aws_vpc_id": "default",
            "aws_keypair_name": "",
            "aws_subnet_id": "default",
            "aws_masters_secgroup_id":"",
            "aws_nodes_secgroup_id":""
        }
    },    
    "cloudAccountName": "GlebAWS"
}
```

Closes #951 