### PR TITLE
Closing response body to avoid resource leak.

### DIFF
--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -1070,6 +1070,7 @@ func (h *Handler) proxyService(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err = io.Copy(w, resp.Body)
+	defer resp.Body.Close()
 
 	if err != nil {
 		message.SendUnknownError(w, err)
@@ -1122,6 +1123,7 @@ func (h *Handler) proxyServiceGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err = io.Copy(w, resp.Body)
+	defer resp.Body.Close()
 
 	if err != nil {
 		message.SendUnknownError(w, err)


### PR DESCRIPTION
https://github.com/supergiant/control/issues/916

Due to response body not being closed, file descriptors leak happened thus exhausting ulimit on boxes. 