### PR TITLE
Add StaticAuth cluster credentials to profiles

### DIFF
--- a/pkg/kube/handler_test.go
+++ b/pkg/kube/handler_test.go
@@ -879,7 +879,7 @@ func TestDeleteNodeFromKube(t *testing.T) {
 			http.StatusNotFound,
 		},
 		{
-			"account unkown error",
+			"account unknown error",
 			"test",
 			"test",
 			&model.Kube{

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -8,6 +8,16 @@ type Profile struct {
 	MasterProfiles []NodeProfile `json:"masterProfiles" valid:"-"`
 	NodesProfiles  []NodeProfile `json:"nodesProfiles" valid:"-"`
 
+	// StaticAuth represents tokens and basic authentication credentials that
+	// would be set to kube-apiserver on start.
+	StaticAuth StaticAuth `json:"staticAuth" valid:"-"`
+
+	// TODO: get rid of its usage
+	// DEPRECATED: should be a part of the static auth
+	User                   string                `json:"user" valid:"-"`
+	// DEPRECATED: should be a part of the static auth
+	Password               string                `json:"password" valid:"-"`
+
 	// TODO(stgleb): In future releases arch will probably migrate to node profile
 	// to allow user create heterogeneous cluster of machine with different arch
 	Provider               clouds.Name           `json:"provider" valid:"in(aws|digitalocean|packet|gce|openstack)" valid:"-"`
@@ -22,8 +32,6 @@ type Profile struct {
 	NetworkType            string                `json:"networkType" valid:"-"`
 	CIDR                   string                `json:"cidr" valid:"-"`
 	HelmVersion            string                `json:"helmVersion" valid:"-"`
-	User                   string                `json:"user" valid:"-"`
-	Password               string                `json:"password" valid:"-"`
 	RBACEnabled            bool                  `json:"rbacEnabled" valid:"-"`
 	CloudSpecificSettings  CloudSpecificSettings `json:"cloudSpecificSettings" valid:"-"`
 	PublicKey              string                `json:"publicKey" valid:"-"`
@@ -32,3 +40,27 @@ type Profile struct {
 
 type NodeProfile map[string]string
 type CloudSpecificSettings map[string]string
+
+// StaticAuth represents tokens and basic authentication credentials.
+type StaticAuth struct {
+	BasicAuth []BasicAuthUser `json:"basicAuth"`
+	Tokens    []TokenAuthUser `json:"tokens"`
+}
+
+// BasicAuthUser represents an entry of the static password file.
+// https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-password-file
+type BasicAuthUser struct {
+	Password string   `json:"password"`
+	Name     string   `json:"name"`
+	ID       string   `json:"id"`
+	Groups   []string `json:"groups"`
+}
+
+// BasicAuthUser represents an entry of the static token file.
+// https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file
+type TokenAuthUser struct {
+	Token  string   `json:"token"`
+	Name   string   `json:"name"`
+	ID     string   `json:"id"`
+	Groups []string `json:"groups"`
+}

--- a/pkg/provisioner/handler.go
+++ b/pkg/provisioner/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/supergiant/control/pkg/account"
 	"github.com/supergiant/control/pkg/message"
 	"github.com/supergiant/control/pkg/model"
+	"github.com/supergiant/control/pkg/pki"
 	"github.com/supergiant/control/pkg/profile"
 	"github.com/supergiant/control/pkg/sgerrors"
 	"github.com/supergiant/control/pkg/util"
@@ -94,9 +95,17 @@ func (h *Handler) Provision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO: use staticAuth instead of user/password
 	if req.Profile.User == "" || req.Profile.Password == "" {
 		req.Profile.User = "root"
 		req.Profile.Password = "1234"
+
+		req.Profile.StaticAuth.BasicAuth = append(req.Profile.StaticAuth.BasicAuth, profile.BasicAuthUser{
+			Password: "1234",
+			Name:     "root",
+			ID:       "1234",
+			Groups:   []string{pki.MastersGroup},
+		})
 	}
 
 	logrus.Infof("Got discoveryUrl %s", discoveryUrl)

--- a/pkg/templatemanager/template_manager.go
+++ b/pkg/templatemanager/template_manager.go
@@ -44,8 +44,10 @@ func Init(templateDir string) error {
 
 			lastTerm := len(strings.Split(f.Name(), "/"))
 			key := strings.Split(strings.Split(f.Name(), "/")[lastTerm-1], ".")[0]
-			t, _ := template.New(key).Parse(string(data))
 
+			t, err := template.New(key).Funcs(template.FuncMap{
+				"stringsJoin": strings.Join,
+			}).Parse(string(data))
 			if err != nil {
 				return err
 			}
@@ -60,7 +62,7 @@ func Init(templateDir string) error {
 func GetTemplate(templateName string) (*template.Template, error) {
 	m.RLock()
 	m.RUnlock()
-	if tpl, ok := templateMap[templateName]; ok {
+	if tpl := templateMap[templateName]; tpl != nil {
 		return tpl, nil
 	} else {
 		return nil, sgerrors.ErrNotFound

--- a/pkg/workflows/steps/certificates/certificates.go
+++ b/pkg/workflows/steps/certificates/certificates.go
@@ -15,7 +15,7 @@ import (
 const StepName = "certificates"
 
 type Step struct {
-	script *template.Template
+	template *template.Template
 }
 
 func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
@@ -24,7 +24,6 @@ func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
 
 func Init() {
 	tpl, err := tm.GetTemplate(StepName)
-
 	if err != nil {
 		panic(fmt.Sprintf("template %s not found", StepName))
 	}
@@ -32,20 +31,19 @@ func Init() {
 	steps.RegisterStep(StepName, New(tpl))
 }
 
-func New(script *template.Template) *Step {
-	t := &Step{
-		script: script,
+func New(tpl *template.Template) *Step {
+	return &Step{
+		template: tpl,
 	}
-
-	return t
 }
 
 func (s *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) error {
+	// TODO: why does these is set here, not on the building config step?
 	config.CertificatesConfig.PrivateIP = config.Node.PrivateIp
 	config.CertificatesConfig.PublicIP = config.Node.PublicIp
 	config.CertificatesConfig.IsMaster = config.IsMaster
 
-	err := steps.RunTemplate(ctx, s.script,
+	err := steps.RunTemplate(ctx, s.template,
 		config.Runner, out, config.CertificatesConfig)
 
 	if err != nil {

--- a/pkg/workflows/steps/certificates/certificates_test.go
+++ b/pkg/workflows/steps/certificates/certificates_test.go
@@ -44,13 +44,11 @@ func TestWriteCertificates(t *testing.T) {
 	)
 
 	err := templatemanager.Init("../../../../templates")
-
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tpl, _ := templatemanager.GetTemplate(StepName)
-
 	if tpl == nil {
 		t.Fatal("template not found")
 	}
@@ -64,11 +62,28 @@ func TestWriteCertificates(t *testing.T) {
 	}
 
 	cfg := steps.NewConfig("", "", "", profile.Profile{})
+	// TODO: update tests
 	cfg.CertificatesConfig = steps.CertificatesConfig{
 		KubernetesConfigDir: kubernetesConfigDir,
 		PrivateIP:           privateIP,
-		Username:            userName,
-		Password:            password,
+		StaticAuth: profile.StaticAuth{
+			BasicAuth: []profile.BasicAuthUser{
+				{
+					Password: "42",
+					Name: "john.doe@sg.io",
+					ID: "john.doe",
+					Groups: []string{"systems:masters", "other:group"},
+				},
+			},
+			Tokens: []profile.TokenAuthUser{
+				{
+					Token: "1234",
+					Name: "user@sg.io",
+					ID: "user",
+					Groups: []string{"systems:masters", "other:group"},
+				},
+			},
+		},
 		CAKey:               string(caPair.Key),
 		CACert:              string(caPair.Cert),
 	}
@@ -230,8 +245,8 @@ func TestNew(t *testing.T) {
 	tpl := template.New("test")
 	s := New(tpl)
 
-	if s.script != tpl {
-		t.Errorf("Wrong template expected %v actual %v", tpl, s.script)
+	if s.template != tpl {
+		t.Errorf("Wrong template expected %v actual %v", tpl, s.template)
 	}
 }
 

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -19,8 +19,12 @@ type CertificatesConfig struct {
 	PrivateIP           string `json:"privateIp"`
 	IsMaster            bool   `json:"isMaster"`
 
-	Username string `json:"username"`
-	Password string `json:"password"`
+	StaticAuth profile.StaticAuth `json:"staticAuth"`
+
+	// DEPRECATED: it's a part of staticAuth
+	Username string
+	// DEPRECATED: it's a part of staticAuth
+	Password string
 
 	AdminCert string `json:"adminCert"`
 	AdminKey  string `json:"adminKey"`
@@ -278,6 +282,7 @@ func NewConfig(clusterName, discoveryUrl, cloudAccountName string, profile profi
 			KubernetesConfigDir: "/etc/kubernetes",
 			Username:            profile.User,
 			Password:            profile.Password,
+			StaticAuth:          profile.StaticAuth,
 		},
 		NetworkConfig: NetworkConfig{
 			EtcdRepositoryUrl: "https://github.com/coreos/etcd/releases/download",

--- a/templates/certificates.tpl
+++ b/templates/certificates.tpl
@@ -51,15 +51,13 @@ sudo chmod 600 /etc/kubernetes/ssl/*-key.pem
 sudo chown root:root /etc/kubernetes/ssl/*-key.pem
 
 sudo bash -c "cat > /etc/kubernetes/ssl/basic_auth.csv <<EOF
-{{ .Password }},{{ .Username }},admin
+{{- range .StaticAuth.BasicAuth }}
+{{ .Password }},{{ .Name }},{{ .ID }},{{ stringsJoin .Groups "," }}
+{{ end -}}
 EOF"
 
 sudo bash -c "cat > /etc/kubernetes/ssl/known_tokens.csv <<EOF
-{{ .Password }},kubelet,kubelet
-{{ .Password }},kube_proxy,kube_proxy
-{{ .Password }},system:scheduler,system:scheduler
-{{ .Password }},system:controller_manager,system:controller_manager
-{{ .Password }},system:logging,system:logging
-{{ .Password }},system:monitoring,system:monitoring
-{{ .Password }},system:dns,system:dns
+{{- range .StaticAuth.Tokens }}
+{{ .Token }},{{ .Name }},{{ .ID }},{{ stringsJoin .Groups "," }}
+{{ end -}}
 EOF"


### PR DESCRIPTION
With this changes it would be possible to provide static password or token credentials for authentication during bootstrap process.

This should be set to profile model:
```
{
...
  "staticAuth": {
    "basicAuth": {
      "password": "userPassword",
      "name": "userName",
      "id":"userId",
      "groups": ["group1", "group2"]
    },
    "tokens": {
      "token": "userToken",
      "name": "userName",
      "id":"userId",
      "groups": ["group1", "group2"]
    }
  }
...
}
```