### PR TITLE
Embed taskIds into cluster and todo tasks to UI

### DIFF
--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -207,7 +207,6 @@ func (h *Handler) getTasks(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		logrus.Error(err)
 		message.SendUnknownError(w, err)
 		return
 	}

--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -207,7 +207,9 @@ func (h *Handler) getTasks(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		logrus.Error(err)
 		message.SendUnknownError(w, err)
+		return
 	}
 
 	if len(tasks) == 0 {
@@ -571,7 +573,8 @@ func (h *Handler) addNode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get cloud account fill appropriate config structure with cloud account credentials
+	// Get cloud account fill appropriate config structure
+	// with cloud account credentials
 	err = util.FillCloudAccountCredentials(r.Context(), acc, config)
 
 	if err != nil {
@@ -580,7 +583,8 @@ func (h *Handler) addNode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx, _ := context.WithTimeout(context.Background(), time.Minute*10)
-	tasks, err := h.nodeProvisioner.ProvisionNodes(ctx, nodeProfiles, k, config)
+	tasks, err := h.nodeProvisioner.ProvisionNodes(ctx, nodeProfiles,
+		k, config)
 
 	if err != nil && sgerrors.IsNotFound(err) {
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -588,6 +592,13 @@ func (h *Handler) addNode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Add tasks ids to kube object
+	k.Tasks = append(k.Tasks, tasks...)
+	if err := h.svc.Create(ctx, k); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -731,23 +742,32 @@ func (h *Handler) deleteNode(w http.ResponseWriter, r *http.Request) {
 
 // TODO(stgleb): Create separte task service to manage task object lifecycle
 func (h *Handler) getKubeTasks(ctx context.Context, kubeID string) ([]*workflows.Task, error) {
-	data, err := h.repo.GetAll(ctx, workflows.Prefix)
+	k, err := h.svc.Get(ctx, kubeID)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "get cluster tasks")
+		return nil, err
 	}
 
-	tasks := make([]*workflows.Task, 0)
-	for _, v := range data {
-		task := &workflows.Task{}
-		err := json.Unmarshal(v, task)
+	tasks := make([]*workflows.Task, 0, len(k.Tasks))
+	for _, taskID := range k.Tasks {
+		t, err := h.repo.Get(ctx, workflows.Prefix, taskID)
+
+		// If one of tasks not found we dont care, because
+		// they may npt be created yet
 		if err != nil {
-			return nil, errors.Wrap(err, "unmarshal task data")
+			logrus.Debugf("task %s not found", taskID)
+			continue
 		}
 
-		if task != nil && task.Config != nil && task.Config.ClusterID == kubeID {
-			tasks = append(tasks, task)
+		task := &workflows.Task{}
+		err = json.Unmarshal(t, task)
+
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"get task %s", taskID)
 		}
+
+		tasks = append(tasks, task)
 	}
 
 	return tasks, nil

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -44,6 +44,8 @@ type Kube struct {
 
 	Masters map[string]*node.Node `json:"masters"`
 	Nodes   map[string]*node.Node `json:"nodes"`
+	// Store taskIds of tasks that are made to provision this kube
+	Tasks   []string              `json:"tasks"`
 }
 
 // Auth holds all possible auth parameters.

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -45,7 +45,7 @@ type Kube struct {
 	Masters map[string]*node.Node `json:"masters"`
 	Nodes   map[string]*node.Node `json:"nodes"`
 	// Store taskIds of tasks that are made to provision this kube
-	Tasks   []string              `json:"tasks"`
+	Tasks []string `json:"tasks"`
 }
 
 // Auth holds all possible auth parameters.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -102,17 +102,7 @@ func (tp *TaskProvisioner) ProvisionCluster(parentContext context.Context,
 	}
 
 	// Gather all task ids
-	taskIds := make([]string, 0)
-	taskIds = append(taskIds, clusterTask.ID)
-
-	for _, task := range masterTasks {
-		taskIds = append(taskIds, task.ID)
-	}
-
-	for _, task := range nodeTasks {
-		taskIds = append(taskIds, task.ID)
-	}
-
+	taskIds := grabTaskIds(clusterTask, masterTasks, nodeTasks)
 	// Save cluster before provisioning
 	err := tp.buildInitialCluster(ctx, profile, masters, nodes, config, taskIds)
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -495,7 +495,7 @@ func (tp *TaskProvisioner) buildInitialCluster(ctx context.Context,
 		CloudSpec: profile.CloudSpecificSettings,
 		Masters:   masters,
 		Nodes:     nodes,
-		Tasks: taskIds,
+		Tasks:     taskIds,
 	}
 
 	return tp.kubeService.Create(ctx, cluster)

--- a/pkg/provisioner/util.go
+++ b/pkg/provisioner/util.go
@@ -178,3 +178,18 @@ func generatePublicKey(publicKey *rsa.PublicKey) ([]byte, error) {
 
 	return pubKeyBytes, nil
 }
+
+func grabTaskIds(clusterTask *workflows.Task, masterTasks, nodeTasks []*workflows.Task) []string {
+	taskIds := make([]string, 0)
+	taskIds = append(taskIds, clusterTask.ID)
+
+	for _, task := range masterTasks {
+		taskIds = append(taskIds, task.ID)
+	}
+
+	for _, task := range nodeTasks {
+		taskIds = append(taskIds, task.ID)
+	}
+
+	return taskIds
+}

--- a/pkg/provisioner/util_test.go
+++ b/pkg/provisioner/util_test.go
@@ -118,3 +118,29 @@ func TestGenerateKeyPair(t *testing.T) {
 
 	privateKeyRSA.Validate()
 }
+
+func TestGrabTaskIds(t *testing.T) {
+	clusterTsk := &workflows.Task{
+		ID: "1234",
+	}
+
+	masterTasks := []*workflows.Task{
+		{
+			ID: "abcd",
+		},
+		{
+			ID: "1sgsg",
+		},
+		{
+			ID: "szrhhrs",
+		},
+	}
+
+	nodeTasks := []*workflows.Task{}
+	taskIds := grabTaskIds(clusterTsk, masterTasks, nodeTasks)
+
+	if len(taskIds) != len(masterTasks) + len(nodeTasks) + 1 {
+		t.Errorf("Wrong task id count expected %d actual %d",
+			len(masterTasks) + len(nodeTasks) + 1, len(taskIds))
+	}
+}

--- a/pkg/workflows/task.go
+++ b/pkg/workflows/task.go
@@ -39,7 +39,13 @@ func NewTask(taskType string, repository storage.Interface) (*Task, error) {
 		return nil, sgerrors.ErrNotFound
 	}
 
-	return newTask(taskType, w, repository), nil
+	t := newTask(taskType, w, repository)
+
+	// Try to sync the task at first time
+	err := t.sync(context.Background())
+
+	return t, err
+
 }
 
 func newTask(workflowType string, workflow Workflow, repository storage.Interface) *Task {


### PR DESCRIPTION
Add task ids into kube object that allows to query cluster task really quick
Sync task to storage right after it is created so todo tasks can be displayed.

Closes #955
Closes #1037 
Closes #1038 