### PR TITLE
Fix nil-pointer dereference in obtaining public IP

### DIFF
--- a/pkg/workflows/steps/amazon/util.go
+++ b/pkg/workflows/steps/amazon/util.go
@@ -41,8 +41,8 @@ func FindOutboundIP(ctx context.Context, findExternalIP func() (string, error)) 
 
 func findOutBoundIP() (string, error) {
 	serviceURLs := []string{
-		"http://myexternalip.com/raw",
 		"http://checkip.amazonaws.com/",
+		"http://myexternalip.com/raw",
 	}
 
 	var (

--- a/pkg/workflows/steps/amazon/util.go
+++ b/pkg/workflows/steps/amazon/util.go
@@ -50,8 +50,11 @@ func findOutBoundIP() (string, error) {
 		err error
 	)
 
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
 	for _, serviceURL := range serviceURLs {
-		resp, err := http.Get(serviceURL)
+		resp, err := client.Get(serviceURL)
 		if err != nil {
 			logrus.Debugf("error while accessing %s", serviceURL)
 			continue

--- a/pkg/workflows/steps/amazon/util.go
+++ b/pkg/workflows/steps/amazon/util.go
@@ -51,6 +51,7 @@ func findOutBoundIP() (string, error) {
 	)
 
 	client := &http.Client{
+		Transport: http.DefaultTransport,
 		Timeout: time.Second * 10,
 	}
 	for _, serviceURL := range serviceURLs {


### PR DESCRIPTION
Dont `resp.Body.Close()` in defer because resp can be nil
Use additional PublicIP service

Partially closes #1068 