### PR TITLE
Readme K8s version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create HA K8s clusters on multiple clouds. Simplify K8s deployment and managemen
 # Features
 
   * Create K8s clusters on **AWS** and **Digital Ocean**
-  * Upstream, **Certified** Kubernetes (version `1.11.1`)
+  * Upstream, **Certified** Kubernetes (version `1.11`)
   * **Helm** releases made easy with an **intuitive UI**
   * At-a-glance **metrics** of cluster resource usage
   * Pluggability for [SG Capacity](https://github.com/supergiant/capacity) and [SG Analyze](https://github.com/supergiant/analyze)


### PR DESCRIPTION
We now use `1.11.5`, so the `README.md`'s certified K8s version was changed to `1.11` in the interest of future-proofing.