### PR TITLE
Use race detector properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ test:
 build:
 	go get -u github.com/hpcloud/tail/...
 	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build -o dist/controlplane-linux -a -installsuffix cgo -ldflags='-extldflags "-static" -w -s -X main.version=${VERSION}' ./cmd/controlplane
-	GOOS=linux GOARCH=amd64 go build -race -o dist/controlplane-linux-race -a -installsuffix cgo -ldflags='-extldflags "-static" -w -s -X main.version=${VERSION}' ./cmd/controlplane
 	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -o dist/controlplane-osx -a -installsuffix cgo -ldflags='-extldflags "-static" -w -s -X main.version=${VERSION}' ./cmd/controlplane
 	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -o dist/controlplane-windows -a -installsuffix cgo -ldflags='-extldflags "-static" -w -s -X main.version=${VERSION}' ./cmd/controlplane
 push:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Running tests"
 
-go test -v -covermode=count -coverprofile=profile.cov ./pkg/...
+go test -v -race -covermode=count -coverprofile=profile.cov ./pkg/...
 if [ $? -eq 0 ]; then
 	echo "Tests Passed"
 else

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Running tests"
 
-go test -v -race -covermode=count -coverprofile=profile.cov ./pkg/...
+go test -v -race -covermode=atomic -coverprofile=profile.cov ./pkg/...
 if [ $? -eq 0 ]; then
 	echo "Tests Passed"
 else


### PR DESCRIPTION
Race detector enabled for unit tests
Race detector disabled for build since it does
work only in runtime