### PR TITLE
Move ssh config to the Kube model

### DIFF
--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"k8s.io/helm/pkg/repo"
+
 	"github.com/supergiant/control/pkg/account"
 	"github.com/supergiant/control/pkg/api"
 	"github.com/supergiant/control/pkg/jwt"
@@ -50,7 +52,6 @@ import (
 	"github.com/supergiant/control/pkg/workflows/steps/ssh"
 	"github.com/supergiant/control/pkg/workflows/steps/storageclass"
 	"github.com/supergiant/control/pkg/workflows/steps/tiller"
-	"k8s.io/helm/pkg/repo"
 )
 
 type Server struct {

--- a/pkg/controlplane/server_test.go
+++ b/pkg/controlplane/server_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )

--- a/pkg/kube/service.go
+++ b/pkg/kube/service.go
@@ -240,8 +240,8 @@ func (s Service) GetCerts(ctx context.Context, kname, cname string) (*Bundle, er
 
 	// TODO(stgleb): pass host info here
 	r, err := ssh.NewRunner(ssh.Config{
-		User: kube.SshUser,
-		Key:  kube.SshPublicKey,
+		User: kube.SSHConfig.User,
+		Key:  []byte(kube.SSHConfig.PublicKey),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "setup runner")

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -29,11 +29,6 @@ type Kube struct {
 	ServicesCIDR string      `json:"servicesCIDR"`
 	APIPort      string      `json:"apiPort"`
 	Auth         Auth        `json:"auth"`
-	SshUser      string      `json:"sshUser"`
-
-	SshPublicKey        []byte `json:"sshKey"`
-	BootstrapPublicKey  []byte `json:"bootstrapPublicKey"`
-	BootstrapPrivateKey []byte `json:"bootstrapPrivateKey"`
 
 	User     string `json:"user" valid:"-"`
 	Password string `json:"password" valid:"-"`
@@ -55,6 +50,25 @@ type Kube struct {
 	Nodes   map[string]*node.Node `json:"nodes"`
 	// Store taskIds of tasks that are made to provision this kube
 	Tasks map[string][]string `json:"tasks"`
+
+	SSHConfig SSHConfig `json:"sshConfig"`
+	// DEPRECATED
+	SshUser string `json:"sshUser"`
+	// DEPRECATED
+	SshPublicKey []byte `json:"sshKey"`
+	// DEPRECATED
+	BootstrapPublicKey []byte `json:"bootstrapPublicKey"`
+	// DEPRECATED
+	BootstrapPrivateKey []byte `json:"bootstrapPrivateKey"`
+}
+
+type SSHConfig struct {
+	User                string `json:"user"`
+	Port                string `json:"port"`
+	BootstrapPrivateKey string `json:"bootstrapPrivateKey"`
+	BootstrapPublicKey  string `json:"bootstrapPublicKey"`
+	PublicKey           string `json:"publicKey"`
+	Timeout             int    `json:"timeout"`
 }
 
 // Auth holds all possible auth parameters.

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -190,7 +190,7 @@ func TestProvisionCluster(t *testing.T) {
 
 	// Cancel context to shut down cluster state monitoring
 	cancel()
-	if k := svc.data[cfg.ClusterID]; k == nil {
+	if k, err := svc.Get(context.Background(), cfg.ClusterID); err == nil && k == nil {
 		t.Errorf("Kube %s not found", k.ID)
 
 		if len(k.Tasks) != len(p.MasterProfiles)+len(p.NodesProfiles)+1 {
@@ -227,10 +227,7 @@ func TestProvisionNodes(t *testing.T) {
 				Size:      "s-2vcpu-4gb",
 			},
 		},
-		BootstrapPublicKey:  []byte(""),
-		BootstrapPrivateKey: []byte(""),
-		SshPublicKey:        []byte(""),
-		CloudSpec:           make(map[string]string),
+		CloudSpec: make(map[string]string),
 	}
 
 	provisioner := TaskProvisioner{

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"gopkg.in/asaskevich/govalidator.v8"
+
 	"github.com/supergiant/control/pkg/message"
 	"github.com/supergiant/control/pkg/sgerrors"
-	"gopkg.in/asaskevich/govalidator.v8"
 )
 
 type TokenIssuer interface {

--- a/pkg/user/service.go
+++ b/pkg/user/service.go
@@ -3,9 +3,10 @@ package user
 import (
 	"context"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/supergiant/control/pkg/sgerrors"
 	"github.com/supergiant/control/pkg/storage"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const DefaultStoragePrefix = "/supergiant/user/"

--- a/pkg/user/service_test.go
+++ b/pkg/user/service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/supergiant/control/pkg/sgerrors"
 	"github.com/supergiant/control/pkg/testutils"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,7 +103,7 @@ func FillCloudAccountCredentials(ctx context.Context, cloudAccount *model.CloudA
 	config.Provider = cloudAccount.Provider
 
 	// Bind private key to config
-	err := BindParams(cloudAccount.Credentials, &config.SshConfig)
+	err := BindParams(cloudAccount.Credentials, &config.Kube.SSHConfig)
 
 	if err != nil {
 		return err
@@ -138,11 +138,9 @@ func LoadCloudSpecificDataFromKube(k *model.Kube, config *steps.Config) error {
 	if k == nil {
 		return sgerrors.ErrNilEntity
 	}
+	config.Kube = *k
 
-	config.SshConfig.BootstrapPublicKey = string(k.BootstrapPublicKey)
-	config.SshConfig.BootstrapPrivateKey = string(k.BootstrapPrivateKey)
-	config.SshConfig.PublicKey = string(k.SshPublicKey)
-
+	// TODO: Is it ok?
 	if k.CloudSpec == nil {
 		return nil
 	}
@@ -158,13 +156,14 @@ func LoadCloudSpecificDataFromKube(k *model.Kube, config *steps.Config) error {
 		config.AWSConfig.KeyPairName = k.CloudSpec[clouds.AwsKeyPairName]
 		config.AWSConfig.MastersSecurityGroupID = k.CloudSpec[clouds.AwsMastersSecGroupID]
 		config.AWSConfig.NodesSecurityGroupID = k.CloudSpec[clouds.AwsNodesSecgroupID]
-		config.SshConfig.BootstrapPrivateKey = k.CloudSpec[clouds.AwsSshBootstrapPrivateKey]
-		config.SshConfig.PublicKey = k.CloudSpec[clouds.AwsUserProvidedSshPublicKey]
 		config.AWSConfig.RouteTableID = k.CloudSpec[clouds.AwsRouteTableID]
 		config.AWSConfig.InternetGatewayID = k.CloudSpec[clouds.AwsInternetGateWayID]
 		config.AWSConfig.MastersInstanceProfile = k.CloudSpec[clouds.AwsMasterInstanceProfile]
 		config.AWSConfig.NodesInstanceProfile = k.CloudSpec[clouds.AwsNodeInstanceProfile]
 		config.AWSConfig.ImageID = k.CloudSpec[clouds.AwsImageID]
+
+		config.Kube.SSHConfig.BootstrapPrivateKey = k.CloudSpec[clouds.AwsSshBootstrapPrivateKey]
+		config.Kube.SSHConfig.PublicKey = k.CloudSpec[clouds.AwsUserProvidedSshPublicKey]
 		return nil
 	case clouds.GCE:
 		config.GCEConfig.Region = k.Region

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -162,9 +162,9 @@ func TestFillCloudAccountCredentials(t *testing.T) {
 			}
 		}
 
-		if config.SshConfig.PublicKey != testCase.cloudAccount.Credentials["publicKey"] {
+		if config.Kube.SSHConfig.PublicKey != testCase.cloudAccount.Credentials["publicKey"] {
 			t.Errorf("PublicKey %s not found in credentials %v",
-				testCase.cloudAccount.Credentials["publicKey"], config.SshConfig.PublicKey)
+				testCase.cloudAccount.Credentials["publicKey"], config.Kube.SSHConfig.PublicKey)
 		}
 
 		if err != testCase.err {
@@ -357,29 +357,18 @@ func TestLoadCloudSpecificDataFromKube(t *testing.T) {
 		{
 			description: "digitalocean",
 			kube: &model.Kube{
-				BootstrapPrivateKey: []byte(`private-key`),
-				BootstrapPublicKey:  []byte(`public-key`),
-				SshPublicKey:        []byte(`public-key2`),
-
 				Region: "fra-1",
 			},
 			provider: clouds.DigitalOcean,
 		},
 		{
 			description: "gce",
-			kube: &model.Kube{
-				BootstrapPrivateKey: []byte(`private-key`),
-				BootstrapPublicKey:  []byte(`public-key`),
-				SshPublicKey:        []byte(`public-key2`),
-			},
-			provider: clouds.GCE,
+			kube:        &model.Kube{},
+			provider:    clouds.GCE,
 		},
 		{
 			description: "aws",
 			kube: &model.Kube{
-				BootstrapPrivateKey: []byte(`private-key`),
-				BootstrapPublicKey:  []byte(`public-key`),
-				SshPublicKey:        []byte(`public-key2`),
 				CloudSpec: map[string]string{
 					clouds.AwsImageID:               "imageId",
 					clouds.AwsVpcID:                 "vpcId",
@@ -400,10 +389,7 @@ func TestLoadCloudSpecificDataFromKube(t *testing.T) {
 		{
 			description: "unsupported",
 			kube: &model.Kube{
-				BootstrapPrivateKey: []byte(`private-key`),
-				BootstrapPublicKey:  []byte(`public-key`),
-				SshPublicKey:        []byte(`public-key2`),
-				CloudSpec:           map[string]string{},
+				CloudSpec: map[string]string{},
 			},
 			provider: clouds.Name("unsupported"),
 			hasErr:   true,
@@ -416,27 +402,23 @@ func TestLoadCloudSpecificDataFromKube(t *testing.T) {
 			description: "cloud spec is nil",
 			hasErr:      false,
 			kube: &model.Kube{
-				Provider:            clouds.AWS,
-				BootstrapPrivateKey: []byte(`private-key`),
-				BootstrapPublicKey:  []byte(`public-key`),
-				SshPublicKey:        []byte(`public-key2`),
+				Provider: clouds.AWS,
 			},
 		},
 	}
 
 	for _, testCase := range testCases {
-		t.Log(testCase.description)
 		config := &steps.Config{
 			Provider: testCase.provider,
 		}
 		err := LoadCloudSpecificDataFromKube(testCase.kube, config)
 
 		if testCase.hasErr && err == nil {
-			t.Errorf("Error must not be nil")
+			t.Errorf("TC: %s: error should not be nil", testCase.description)
 		}
 
 		if !testCase.hasErr && err != nil {
-			t.Errorf("unexpected error %v", err)
+			t.Errorf("TC: %s: unexpected error %v", testCase.description, err)
 		}
 	}
 }

--- a/pkg/workflows/hanlder_test.go
+++ b/pkg/workflows/hanlder_test.go
@@ -122,10 +122,11 @@ func TestTaskHandlerRestartTask(t *testing.T) {
 	task := &Task{
 		ID: taskId,
 		Config: &steps.Config{
-			SshConfig: steps.SshConfig{
-				User: "root",
-				Port: "22",
-				BootstrapPrivateKey: `-----BEGIN RSA PRIVATE KEY-----
+			Kube: model.Kube{
+				SSHConfig: model.SSHConfig{
+					User: "root",
+					Port: "22",
+					BootstrapPrivateKey: `-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAtArxGzmUffkRNy4bpITg0oicUA6itrh2RumMoydra2QqRL8i
 sA6xBaPHbBAOJO/gY/h/qvr8Hnb38GFJcQQy2eENb83i2u8BVnnN2IFkgyCyYCN7
 DE54bQejH0xD4qMhXdyEUOyKaOBzHHBliyIR4HmobiddJho4G0Ku3onLDm+++XNG
@@ -152,7 +153,8 @@ dVUN1U8CgYEAw5N6ScysYb9Jsaurcykij4mn1tvXzpDcap/Lqu/QXSUJZU1D7Cac
 OOJSve1MuYQbV1LEIc15yMPsWTTik2Z98r9IL+3xdofh9yFaG1nxzi9OkN6aVMAz
 dZM6MSCYh9kcT0pi2FPmY9iXba9kx4XAnf+0YB5xCz9QSMk4W5xSTBs=
 -----END RSA PRIVATE KEY-----`,
-				Timeout: 10,
+					Timeout: 10,
+				},
 			},
 			Node: node.Node{
 				PublicIp: "10.20.30.40",

--- a/pkg/workflows/steps/amazon/import_keypair.go
+++ b/pkg/workflows/steps/amazon/import_keypair.go
@@ -74,7 +74,7 @@ func (s *KeyPairStep) Run(ctx context.Context, w io.Writer, cfg *steps.Config) e
 		s.Name(), bootstrapKeyPairName)
 	req := &ec2.ImportKeyPairInput{
 		KeyName:           &bootstrapKeyPairName,
-		PublicKeyMaterial: []byte(cfg.SshConfig.BootstrapPublicKey),
+		PublicKeyMaterial: []byte(cfg.Kube.SSHConfig.BootstrapPublicKey),
 	}
 
 	output, err := svc.ImportKeyPairWithContext(ctx, req)

--- a/pkg/workflows/steps/authorizedKeys/add_authorized_key.go
+++ b/pkg/workflows/steps/authorizedKeys/add_authorized_key.go
@@ -38,8 +38,8 @@ func (s *Step) Run(ctx context.Context, w io.Writer, cfg *steps.Config) error {
 	log := util.GetLogger(w)
 
 	log.Infof("[%s] - adding user's public key to the node", s.Name())
-	if cfg.SshConfig.PublicKey != "" {
-		err := steps.RunTemplate(ctx, s.script, cfg.Runner, w, cfg.SshConfig)
+	if cfg == nil || cfg.Kube.SSHConfig.PublicKey != "" {
+		err := steps.RunTemplate(ctx, s.script, cfg.Runner, w, cfg.Kube.SSHConfig)
 		if err != nil {
 			return errors.Wrap(err, "add authorized key step")
 		}

--- a/pkg/workflows/steps/authorizedKeys/authorized_keys_test.go
+++ b/pkg/workflows/steps/authorizedKeys/authorized_keys_test.go
@@ -84,7 +84,7 @@ func TestAuthorizedKeysErr(t *testing.T) {
 
 	cfg := steps.NewConfig("", "",
 		"", profile.Profile{})
-	cfg.SshConfig.PublicKey = "key"
+	cfg.Kube.SSHConfig.PublicKey = "key"
 	cfg.Runner = r
 	cfg.AddMaster(&node.Node{
 		State:     node.StateActive,

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -179,15 +179,6 @@ type EtcdConfig struct {
 	ClusterToken   string        `json:"clusterToken"`
 }
 
-type SshConfig struct {
-	User                string `json:"user"`
-	Port                string `json:"port"`
-	BootstrapPrivateKey string `json:"bootstrapPrivateKey"`
-	BootstrapPublicKey  string `json:"bootstrapPublicKey"`
-	PublicKey           string `json:"publicKey"`
-	Timeout             int    `json:"timeout"`
-}
-
 type ClusterCheckConfig struct {
 	MachineCount int
 }
@@ -220,6 +211,8 @@ func NewMap(m map[string]*node.Node) Map {
 }
 
 type Config struct {
+	Kube model.Kube `json:"kube"`
+
 	TaskID                 string
 	Provider               clouds.Name  `json:"provider"`
 	IsMaster               bool         `json:"isMaster"`
@@ -242,7 +235,6 @@ type Config struct {
 	PostStartConfig    PostStartConfig    `json:"postStartConfig"`
 	TillerConfig       TillerConfig       `json:"tillerConfig"`
 	EtcdConfig         EtcdConfig         `json:"etcdConfig"`
-	SshConfig          SshConfig          `json:"sshConfig"`
 	PrometheusConfig   PrometheusConfig   `json:"prometheusConfig"`
 	DrainConfig        DrainConfig        `json:"drainConfig"`
 
@@ -272,6 +264,14 @@ type Config struct {
 // NewConfig builds instance of config for provisioning
 func NewConfig(clusterName, clusterToken, cloudAccountName string, profile profile.Profile) *Config {
 	return &Config{
+		Kube: model.Kube{
+			SSHConfig: model.SSHConfig{
+				Port:      "22",
+				User:      "root",
+				Timeout:   10,
+				PublicKey: profile.PublicKey,
+			},
+		},
 		Provider:    profile.Provider,
 		ClusterName: clusterName,
 		DigitalOceanConfig: DOConfig{
@@ -357,12 +357,6 @@ func NewConfig(clusterName, clusterToken, cloudAccountName string, profile profi
 			Arch:            profile.Arch,
 			RBACEnabled:     profile.RBACEnabled,
 		},
-		SshConfig: SshConfig{
-			Port:      "22",
-			User:      "root",
-			Timeout:   10,
-			PublicKey: profile.PublicKey,
-		},
 		EtcdConfig: EtcdConfig{
 			// TODO(stgleb): this field must be changed per node
 			Name:           "etcd0",
@@ -402,7 +396,7 @@ func NewConfig(clusterName, clusterToken, cloudAccountName string, profile profi
 func NewConfigFromKube(profile *profile.Profile, k *model.Kube) *Config {
 	clusterToken := uuid.New()
 
-	return &Config{
+	cfg := &Config{
 		ClusterID:   k.ID,
 		Provider:    profile.Provider,
 		ClusterName: k.Name,
@@ -492,12 +486,6 @@ func NewConfigFromKube(profile *profile.Profile, k *model.Kube) *Config {
 			Arch:            profile.Arch,
 			RBACEnabled:     profile.RBACEnabled,
 		},
-		SshConfig: SshConfig{
-			Port:      "22",
-			User:      "root",
-			Timeout:   10,
-			PublicKey: profile.PublicKey,
-		},
 		EtcdConfig: EtcdConfig{
 			// TODO(stgleb): this field must be changed per node
 			Name:           "etcd0",
@@ -527,11 +515,23 @@ func NewConfigFromKube(profile *profile.Profile, k *model.Kube) *Config {
 		},
 		Timeout:          time.Minute * 30,
 		CloudAccountName: k.AccountName,
-
-		nodeChan:      make(chan node.Node, len(profile.MasterProfiles)+len(profile.NodesProfiles)),
-		kubeStateChan: make(chan model.KubeState, 5),
-		configChan:    make(chan *Config),
+		nodeChan:         make(chan node.Node, len(profile.MasterProfiles)+len(profile.NodesProfiles)),
+		kubeStateChan:    make(chan model.KubeState, 5),
+		configChan:       make(chan *Config),
 	}
+
+	if k != nil {
+		cfg.Kube = *k
+
+		cfg.Kube.SSHConfig = model.SSHConfig{
+			Port:      "22",
+			User:      "root",
+			Timeout:   10,
+			PublicKey: profile.PublicKey,
+		}
+	}
+
+	return cfg
 }
 
 // AddMaster to map of master, map is used because it is reference and can be shared among

--- a/pkg/workflows/steps/digitalocean/create_instance.go
+++ b/pkg/workflows/steps/digitalocean/create_instance.go
@@ -164,7 +164,7 @@ func (s *CreateInstanceStep) createKeys(ctx context.Context, keyService KeyServi
 	// Create key for provisioning
 	key, err := createKey(ctx, keyService,
 		util.MakeKeyName(config.DigitalOceanConfig.Name, false),
-		config.SshConfig.BootstrapPublicKey)
+		config.Kube.SSHConfig.BootstrapPublicKey)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "create provision key")
@@ -177,12 +177,12 @@ func (s *CreateInstanceStep) createKeys(ctx context.Context, keyService KeyServi
 	// Create user provided key
 	key, _ = createKey(ctx, keyService,
 		util.MakeKeyName(config.DigitalOceanConfig.Name, true),
-		config.SshConfig.PublicKey)
+		config.Kube.SSHConfig.PublicKey)
 
 	// NOTE(stgleb): In case if this key is already used by user of this account
 	// just compute fingerprint and pass it
 	if key == nil {
-		fg, _ := fingerprint(config.SshConfig.PublicKey)
+		fg, _ := fingerprint(config.Kube.SSHConfig.PublicKey)
 		fingers = append(fingers, godo.DropletCreateSSHKey{
 			Fingerprint: fg,
 		})

--- a/pkg/workflows/steps/digitalocean/delete_keys.go
+++ b/pkg/workflows/steps/digitalocean/delete_keys.go
@@ -36,7 +36,7 @@ func NewDeleteKeysStep() *DeleteKeysStep {
 func (s *DeleteKeysStep) Run(ctx context.Context, output io.Writer, config *steps.Config) error {
 	keyService := s.getKeyService(config.DigitalOceanConfig.AccessToken)
 
-	bootstrapFg, err := fingerprint(config.SshConfig.BootstrapPublicKey)
+	bootstrapFg, err := fingerprint(config.Kube.SSHConfig.BootstrapPublicKey)
 
 	if err != nil {
 		logrus.Debugf("error computing fingerprint of bootstrap key")
@@ -49,7 +49,7 @@ func (s *DeleteKeysStep) Run(ctx context.Context, output io.Writer, config *step
 			resp.Status, err)
 	}
 
-	publicFg, err := fingerprint(config.SshConfig.PublicKey)
+	publicFg, err := fingerprint(config.Kube.SSHConfig.PublicKey)
 
 	if err != nil {
 		logrus.Debugf("error computing fingerprint of public key")

--- a/pkg/workflows/steps/digitalocean/delete_keys_test.go
+++ b/pkg/workflows/steps/digitalocean/delete_keys_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitalocean/godo"
 
+	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/sgerrors"
 	"github.com/supergiant/control/pkg/workflows/steps"
 )
@@ -102,9 +103,11 @@ func TestDeleteKeysStep_Run(t *testing.T) {
 		}
 
 		config := &steps.Config{
-			SshConfig: steps.SshConfig{
-				PublicKey:          testKey,
-				BootstrapPublicKey: testKey,
+			Kube: model.Kube{
+				SSHConfig: model.SSHConfig{
+					PublicKey:          testKey,
+					BootstrapPublicKey: testKey,
+				},
 			},
 		}
 		step.Run(context.Background(), ioutil.Discard, config)

--- a/pkg/workflows/steps/drain/drain_node.go
+++ b/pkg/workflows/steps/drain/drain_node.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/supergiant/control/pkg/clouds"
 	"github.com/supergiant/control/pkg/runner"
 	"github.com/supergiant/control/pkg/runner/ssh"
 	"github.com/supergiant/control/pkg/sgerrors"
 	tm "github.com/supergiant/control/pkg/templatemanager"
 	"github.com/supergiant/control/pkg/workflows/steps"
-	"github.com/supergiant/control/pkg/clouds"
 )
 
 const StepName = "drain"
@@ -44,15 +44,15 @@ func New(script *template.Template) *Step {
 			if config.Provider == clouds.AWS {
 				//on aws default user name on ubuntu images are not root but ubuntu
 				//https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html
-				config.SshConfig.User = "ubuntu"
+				config.Kube.SSHConfig.User = "ubuntu"
 			}
 
 			cfg := ssh.Config{
 				Host:    masterIp,
-				Port:    config.SshConfig.Port,
-				User:    config.SshConfig.User,
+				Port:    config.Kube.SSHConfig.Port,
+				User:    config.Kube.SSHConfig.User,
 				Timeout: 10,
-				Key:     []byte(config.SshConfig.BootstrapPrivateKey),
+				Key:     []byte(config.Kube.SSHConfig.BootstrapPrivateKey),
 			}
 
 			sshRunner, err := ssh.NewRunner(cfg)

--- a/pkg/workflows/steps/drain/drain_node_test.go
+++ b/pkg/workflows/steps/drain/drain_node_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/node"
 	"github.com/supergiant/control/pkg/profile"
 	"github.com/supergiant/control/pkg/runner"
@@ -91,10 +92,10 @@ func TestDrain(t *testing.T) {
 			PublicIp: "10.20.30.40",
 		},
 	})
-	cfg.SshConfig = steps.SshConfig{
+	cfg.Kube.SSHConfig = model.SSHConfig{
 		BootstrapPrivateKey: privateKey,
-		User: "root",
-		Port: ssh.DefaultPort,
+		User:                "root",
+		Port:                ssh.DefaultPort,
 	}
 
 	task := &Step{
@@ -128,7 +129,7 @@ func TestErrors(t *testing.T) {
 	output := new(bytes.Buffer)
 
 	task := &Step{
-		script:proxyTemplate,
+		script: proxyTemplate,
 		getRunner: func(masterIP string, config *steps.Config) (runner.Runner, error) {
 			return r, nil
 		},
@@ -196,10 +197,12 @@ func TestNew(t *testing.T) {
 	}
 
 	cfg := &steps.Config{
-		SshConfig: steps.SshConfig{
-			BootstrapPrivateKey: privateKey,
-			User: "root",
-			Port: ssh.DefaultPort,
+		Kube: model.Kube{
+			SSHConfig: model.SSHConfig{
+				BootstrapPrivateKey: privateKey,
+				User:                "root",
+				Port:                ssh.DefaultPort,
+			},
 		},
 	}
 
@@ -221,9 +224,7 @@ func TestNewErr(t *testing.T) {
 		t.Errorf("getRunner function must not be nil")
 	}
 
-	cfg := &steps.Config{
-		SshConfig: steps.SshConfig{},
-	}
+	cfg := &steps.Config{}
 
 	if _, err := s.getRunner("10.20.30.40", cfg); err == nil {
 		t.Errorf("Error must not be nil")

--- a/pkg/workflows/steps/gce/create_instance.go
+++ b/pkg/workflows/steps/gce/create_instance.go
@@ -112,7 +112,7 @@ func (s *CreateInstanceStep) Run(ctx context.Context, output io.Writer,
 
 	// TODO(stgleb): also copy user provided ssh key
 	publicKey := fmt.Sprintf("%s:%s",
-		config.SshConfig.User, config.SshConfig.BootstrapPublicKey)
+		config.Kube.SSHConfig.User, config.Kube.SSHConfig.BootstrapPublicKey)
 	// Put bootstrap key to instance metadata that allows ssh connection to the node
 	metadata := &compute.Metadata{
 		Items: []*compute.MetadataItems{

--- a/pkg/workflows/steps/poststart/post_start.go
+++ b/pkg/workflows/steps/poststart/post_start.go
@@ -59,7 +59,7 @@ func (s *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	// Mark current node as active to allow cluster check task select it for cluster wide task
 	config.Node.State = node.StateActive
 	config.NodeChan() <- config.Node
-	config.SshConfig.BootstrapPrivateKey = ""
+	config.Kube.SSHConfig.BootstrapPrivateKey = ""
 
 	return nil
 }

--- a/pkg/workflows/steps/ssh/ssh.go
+++ b/pkg/workflows/steps/ssh/ssh.go
@@ -25,20 +25,19 @@ func (s *Step) Run(ctx context.Context, writer io.Writer, config *steps.Config) 
 	if config.Provider == clouds.AWS {
 		//on aws default user name on ubuntu images are not root but ubuntu
 		//https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html
-		config.SshConfig.User = "ubuntu"
+		// TODO: this should be set by provisioner
+		config.Kube.SSHConfig.User = "ubuntu"
 	}
-
 	cfg := ssh.Config{
 		Host:    config.Node.PublicIp,
-		Port:    config.SshConfig.Port,
-		User:    config.SshConfig.User,
-		Timeout: config.SshConfig.Timeout,
+		Port:    config.Kube.SSHConfig.Port,
+		User:    config.Kube.SSHConfig.User,
+		Timeout: config.Kube.SSHConfig.Timeout,
 		// TODO(stgleb): Use secure storage for private keys instead carrying them in plain text
-		Key: []byte(config.SshConfig.BootstrapPrivateKey),
+		Key: []byte(config.Kube.SSHConfig.BootstrapPrivateKey),
 	}
 
 	config.Runner, err = ssh.NewRunner(cfg)
-
 	if err != nil {
 		return errors.Wrap(err, "ssh config step")
 	}

--- a/pkg/workflows/steps/ssh/ssh_test.go
+++ b/pkg/workflows/steps/ssh/ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/node"
 	"github.com/supergiant/control/pkg/profile"
 	"github.com/supergiant/control/pkg/workflows/steps"
@@ -47,7 +48,7 @@ func TestStepRunSuccess(t *testing.T) {
 	timeout := 120
 
 	config := steps.NewConfig("", "", "", profile.Profile{})
-	config.SshConfig = steps.SshConfig{
+	config.Kube.SSHConfig = model.SSHConfig{
 		Port:                port,
 		User:                user,
 		Timeout:             timeout,
@@ -88,7 +89,7 @@ func TestStepRunError(t *testing.T) {
 	config.Node = node.Node{
 		PrivateIp: host,
 	}
-	config.SshConfig = steps.SshConfig{
+	config.Kube.SSHConfig = model.SSHConfig{
 		Port:                port,
 		User:                user,
 		Timeout:             timeout,

--- a/pkg/workflows/utils.go
+++ b/pkg/workflows/utils.go
@@ -25,10 +25,10 @@ func DeserializeTask(data []byte, repository storage.Interface) (*Task, error) {
 	if task.Config != nil && task.Config.Node.PublicIp != "" {
 		cfg := ssh.Config{
 			Host:    task.Config.Node.PublicIp,
-			Port:    task.Config.SshConfig.Port,
-			User:    task.Config.SshConfig.User,
-			Timeout: task.Config.SshConfig.Timeout,
-			Key:     []byte(task.Config.SshConfig.BootstrapPrivateKey),
+			Port:    task.Config.Kube.SSHConfig.Port,
+			User:    task.Config.Kube.SSHConfig.User,
+			Timeout: task.Config.Kube.SSHConfig.Timeout,
+			Key:     []byte(task.Config.Kube.SSHConfig.BootstrapPrivateKey),
 		}
 
 		task.Config.Runner, err = ssh.NewRunner(cfg)

--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -13,6 +13,7 @@ import (
 	"github.com/supergiant/control/pkg/workflows/steps/digitalocean"
 	"github.com/supergiant/control/pkg/workflows/steps/docker"
 	"github.com/supergiant/control/pkg/workflows/steps/downloadk8sbinary"
+	"github.com/supergiant/control/pkg/workflows/steps/drain"
 	"github.com/supergiant/control/pkg/workflows/steps/etcd"
 	"github.com/supergiant/control/pkg/workflows/steps/flannel"
 	"github.com/supergiant/control/pkg/workflows/steps/gce"
@@ -24,7 +25,6 @@ import (
 	"github.com/supergiant/control/pkg/workflows/steps/ssh"
 	"github.com/supergiant/control/pkg/workflows/steps/storageclass"
 	"github.com/supergiant/control/pkg/workflows/steps/tiller"
-	"github.com/supergiant/control/pkg/workflows/steps/drain"
 )
 
 // StepStatus aggregates data that is needed to track progress


### PR DESCRIPTION
Control uses different types for cluster bootstrapping and representation; the idea here to use kube model for both. 
This change is a part of merging a provisioner config and a cluster model.