### PR TITLE
Introduce provider steps to provisioner workflows

### DIFF
--- a/pkg/workflows/steps/provider/cleanup.go
+++ b/pkg/workflows/steps/provider/cleanup.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/supergiant/control/pkg/clouds"
+	"github.com/supergiant/control/pkg/workflows/steps"
+	"github.com/supergiant/control/pkg/workflows/steps/amazon"
+	"github.com/supergiant/control/pkg/workflows/steps/digitalocean"
+	"github.com/supergiant/control/pkg/workflows/steps/gce"
+)
+
+const (
+	CleanUpStep = "cleanUp"
+)
+
+type StepCleanUp struct {
+}
+
+func (s StepCleanUp) Run(ctx context.Context, out io.Writer, cfg *steps.Config) error {
+	if cfg == nil {
+		return errors.New("invalid config")
+	}
+
+	steps, err := cleanUpStepsFor(cfg.Provider)
+	if err != nil {
+		return errors.Wrap(err, CleanUpStep)
+	}
+	for _, s := range steps {
+		if err = s.Run(ctx, out, cfg); err != nil {
+			return errors.Wrap(err, CleanUpStep)
+		}
+	}
+
+	return nil
+}
+
+func (s StepCleanUp) Name() string {
+	return CleanUpStep
+}
+
+func (s StepCleanUp) Description() string {
+	return CleanUpStep
+}
+
+func (s StepCleanUp) Depends() []string {
+	return nil
+}
+
+func (s StepCleanUp) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
+func cleanUpStepsFor(provider clouds.Name) ([]steps.Step, error) {
+	// TODO: use provider interface
+	switch provider {
+	case clouds.AWS:
+		return []steps.Step{
+			steps.GetStep(amazon.DeleteClusterMachinesStepName),
+			steps.GetStep(amazon.DeleteSecurityGroupsStepName),
+			steps.GetStep(amazon.DisassociateRouteTableStepName),
+			steps.GetStep(amazon.DeleteSubnetsStepName),
+			steps.GetStep(amazon.DeleteRouteTableStepName),
+			steps.GetStep(amazon.DeleteInternetGatewayStepName),
+			steps.GetStep(amazon.DeleteKeyPairStepName),
+			steps.GetStep(amazon.DeleteVPCStepName),
+		}, nil
+	case clouds.DigitalOcean:
+		return []steps.Step{
+			steps.GetStep(digitalocean.DeleteMachineStepName),
+			steps.GetStep(digitalocean.DeleteDeleteKeysStepName),
+		}, nil
+	case clouds.GCE:
+		return []steps.Step{
+			steps.GetStep(gce.DeleteNodeStepName),
+		}, nil
+	}
+	return nil, errors.New(fmt.Sprintf("unknown provider: %s", provider))
+}

--- a/pkg/workflows/steps/provider/create_machine.go
+++ b/pkg/workflows/steps/provider/create_machine.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/supergiant/control/pkg/clouds"
+	"github.com/supergiant/control/pkg/workflows/steps"
+	"github.com/supergiant/control/pkg/workflows/steps/amazon"
+	"github.com/supergiant/control/pkg/workflows/steps/digitalocean"
+	"github.com/supergiant/control/pkg/workflows/steps/gce"
+)
+
+const (
+	CreateMachineStep = "createMachine"
+)
+
+type StepCreateMachine struct {
+}
+
+func (s StepCreateMachine) Run(ctx context.Context, out io.Writer, cfg *steps.Config) error {
+	if cfg == nil {
+		return errors.New("invalid config")
+	}
+
+	step, err := createMachineStepFor(cfg.Provider)
+	if err != nil {
+		return err
+	}
+
+	return step.Run(ctx, out, cfg)
+}
+
+func (s StepCreateMachine) Name() string {
+	return CreateMachineStep
+}
+
+func (s StepCreateMachine) Description() string {
+	return CreateMachineStep
+}
+
+func (s StepCreateMachine) Depends() []string {
+	return nil
+}
+
+func (s StepCreateMachine) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
+func createMachineStepFor(provider clouds.Name) (steps.Step, error) {
+	switch provider {
+	case clouds.AWS:
+		return steps.GetStep(amazon.StepNameCreateEC2Instance), nil
+	case clouds.DigitalOcean:
+		return steps.GetStep(digitalocean.CreateMachineStepName), nil
+	case clouds.GCE:
+		return steps.GetStep(gce.CreateInstanceStepName), nil
+	}
+	return nil, errors.New(fmt.Sprintf("unknown provider: %s", provider))
+}

--- a/pkg/workflows/steps/provider/delete_machine.go
+++ b/pkg/workflows/steps/provider/delete_machine.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/supergiant/control/pkg/clouds"
+	"github.com/supergiant/control/pkg/workflows/steps"
+	"github.com/supergiant/control/pkg/workflows/steps/amazon"
+	"github.com/supergiant/control/pkg/workflows/steps/digitalocean"
+	"github.com/supergiant/control/pkg/workflows/steps/gce"
+)
+
+const (
+	DeleteMachineStep = "deleteMachine"
+)
+
+type StepDeleteMachine struct {
+}
+
+func (s StepDeleteMachine) Run(ctx context.Context, out io.Writer, cfg *steps.Config) error {
+	if cfg == nil {
+		return errors.New("invalid config")
+	}
+
+	step, err := deleteMachineStepFor(cfg.Provider)
+	if err != nil {
+		return err
+	}
+
+	return step.Run(ctx, out, cfg)
+}
+
+func (s StepDeleteMachine) Name() string {
+	return DeleteMachineStep
+}
+
+func (s StepDeleteMachine) Description() string {
+	return DeleteMachineStep
+}
+
+func (s StepDeleteMachine) Depends() []string {
+	return nil
+}
+
+func (s StepDeleteMachine) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
+func deleteMachineStepFor(provider clouds.Name) (steps.Step, error) {
+	switch provider {
+	case clouds.AWS:
+		return steps.GetStep(amazon.DeleteNodeStepName), nil
+	case clouds.DigitalOcean:
+		return steps.GetStep(digitalocean.DeleteMachineStepName), nil
+	case clouds.GCE:
+		return steps.GetStep(gce.DeleteNodeStepName), nil
+	}
+	return nil, errors.New(fmt.Sprintf("unknown provider: %s", provider))
+}

--- a/pkg/workflows/steps/provider/preprovision.go
+++ b/pkg/workflows/steps/provider/preprovision.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/supergiant/control/pkg/clouds"
+	"github.com/supergiant/control/pkg/workflows/steps"
+	"github.com/supergiant/control/pkg/workflows/steps/amazon"
+)
+
+const (
+	PreProvisionStep = "preProvision"
+)
+
+type StepPreProvision struct {
+}
+
+func (s StepPreProvision) Run(ctx context.Context, out io.Writer, cfg *steps.Config) error {
+	if cfg == nil {
+		return errors.New("invalid config")
+	}
+
+	steps, err := prepProvisionStepFor(cfg.Provider)
+	if err != nil {
+		return errors.Wrap(err, PreProvisionStep)
+	}
+	for _, s := range steps {
+		if err = s.Run(ctx, out, cfg); err != nil {
+			return errors.Wrap(err, PreProvisionStep)
+		}
+	}
+
+	return nil
+}
+
+func (s StepPreProvision) Name() string {
+	return PreProvisionStep
+}
+
+func (s StepPreProvision) Description() string {
+	return PreProvisionStep
+}
+
+func (s StepPreProvision) Depends() []string {
+	return nil
+}
+
+func (s StepPreProvision) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
+func prepProvisionStepFor(provider clouds.Name) ([]steps.Step, error) {
+	// TODO: use provider interface
+	switch provider {
+	case clouds.AWS:
+		return []steps.Step{
+			steps.GetStep(amazon.StepFindAMI),
+			steps.GetStep(amazon.StepCreateVPC),
+			steps.GetStep(amazon.StepCreateSecurityGroups),
+			steps.GetStep(amazon.StepNameCreateInstanceProfiles),
+			steps.GetStep(amazon.StepImportKeyPair),
+			steps.GetStep(amazon.StepCreateInternetGateway),
+			steps.GetStep(amazon.StepCreateSubnets),
+			steps.GetStep(amazon.StepCreateRouteTable),
+			steps.GetStep(amazon.StepAssociateRouteTable),
+		}, nil
+	case clouds.DigitalOcean:
+		return []steps.Step{}, nil
+	case clouds.GCE:
+		return []steps.Step{}, nil
+	}
+	return nil, errors.New(fmt.Sprintf("unknown provider: %s", provider))
+}


### PR DESCRIPTION
All cluster provisioning worflows (awsMaster, gceMaster etc) use the same set of steps except of the working with the cloud infrastructure ones.

Add provider steps to unify interaction with different infrastructure providers.