### PR TITLE
Add support for Azure accounts

### DIFF
--- a/pkg/account/handler.go
+++ b/pkg/account/handler.go
@@ -59,7 +59,7 @@ func (h *Handler) Create(rw http.ResponseWriter, r *http.Request) {
 	// Check account data for validity
 	if err := h.validator.ValidateCredentials(account); err != nil {
 		logrus.Errorf("error validating credentials %v", err)
-		message.SendInvalidCredentials(rw, err)
+		message.SendValidationFailed(rw, err)
 		return
 	}
 

--- a/pkg/account/service_test.go
+++ b/pkg/account/service_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/supergiant/control/pkg/clouds"
 	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/sgerrors"
 	"github.com/supergiant/control/pkg/testutils"
@@ -47,35 +46,6 @@ func TestServiceCreate(t *testing.T) {
 				Name:     "test",
 				Provider: "nonameprovider",
 			},
-		},
-		{
-			getResponse: nil,
-			getError:    sgerrors.ErrNotFound,
-			account: &model.CloudAccount{
-				Name:     "test",
-				Provider: "nonameprovider",
-			},
-			expectedErr: ErrUnsupportedProvider,
-		},
-		{
-			getResponse: nil,
-			getError:    sgerrors.ErrNotFound,
-			account: &model.CloudAccount{
-				Name:        "test",
-				Provider:    clouds.DigitalOcean,
-				Credentials: map[string]string{},
-			},
-			expectedErr: sgerrors.ErrInvalidCredentials,
-		},
-		{
-			getResponse: nil,
-			getError:    sgerrors.ErrNotFound,
-			account: &model.CloudAccount{
-				Name:        "test",
-				Provider:    clouds.AWS,
-				Credentials: map[string]string{},
-			},
-			expectedErr: sgerrors.ErrInvalidCredentials,
 		},
 	}
 

--- a/pkg/clouds/constants.go
+++ b/pkg/clouds/constants.go
@@ -9,6 +9,7 @@ const (
 	DigitalOcean Name = "digitalocean"
 	Packet       Name = "packet"
 	GCE          Name = "gce"
+	Azure        Name = "azure"
 	OpenStack    Name = "openstack"
 
 	Unknown Name = "unknown"
@@ -58,4 +59,11 @@ const (
 	AwsMasterInstanceProfile    = "aws_master_instance_profile"
 	AwsNodeInstanceProfile      = "aws_node_instance_profile"
 	AwsImageID                  = "aws_image_id"
+
+	// Use client credentials auth model for azure.
+	// https://github.com/Azure/azure-sdk-for-go#more-authentication-details
+	AzureTenantID       = "azureTenantId"
+	AzureSubscriptionID = "azureSubscriptionId"
+	AzureClientID       = "azureClientId"
+	AzureClientSecret   = "azureClientSecret"
 )

--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -12,11 +12,10 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	"github.com/rakyll/statik/fs"
 	"github.com/sirupsen/logrus"
 	"k8s.io/helm/pkg/repo"
-	"github.com/rakyll/statik/fs"
 
-	_ "github.com/supergiant/control/statik"
 	"github.com/supergiant/control/pkg/account"
 	"github.com/supergiant/control/pkg/api"
 	"github.com/supergiant/control/pkg/jwt"
@@ -51,6 +50,7 @@ import (
 	"github.com/supergiant/control/pkg/workflows/steps/ssh"
 	"github.com/supergiant/control/pkg/workflows/steps/storageclass"
 	"github.com/supergiant/control/pkg/workflows/steps/tiller"
+	_ "github.com/supergiant/control/statik"
 )
 
 type Server struct {
@@ -144,7 +144,6 @@ func validate(cfg *Config) error {
 	if cfg.Port <= 0 {
 		return errors.New("port can't be negative")
 	}
-
 
 	if cfg.SpawnInterval == 0 {
 		return errors.New("spawn interval must not be 0")

--- a/pkg/model/account.go
+++ b/pkg/model/account.go
@@ -8,6 +8,6 @@ import (
 // Name should be unique.
 type CloudAccount struct {
 	Name        string            `json:"name" valid:"required, length(1|32)"`
-	Provider    clouds.Name       `json:"provider" valid:"in(aws|digitalocean|packet|gce|openstack)"`
+	Provider    clouds.Name       `json:"provider" valid:"in(aws|digitalocean|gce|azure)"`
 	Credentials map[string]string `json:"credentials" valid:"optional"`
 }

--- a/pkg/storage/etcd/etcd.go
+++ b/pkg/storage/etcd/etcd.go
@@ -3,8 +3,9 @@ package etcd
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/coreos/etcd/clientv3"
+	"github.com/pkg/errors"
+
 	"github.com/supergiant/control/pkg/sgerrors"
 )
 

--- a/pkg/storage/file/file.go
+++ b/pkg/storage/file/file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/etcd-io/bbolt"
+
 	"github.com/supergiant/control/pkg/sgerrors"
 )
 

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -2,14 +2,14 @@ package memory
 
 import (
 	"context"
-	"sync"
 	"strings"
+	"sync"
 
 	"github.com/supergiant/control/pkg/sgerrors"
 )
 
 type InMemoryRepository struct {
-	m sync.RWMutex
+	m    sync.RWMutex
 	data map[string][]byte
 }
 
@@ -23,7 +23,7 @@ func (i *InMemoryRepository) Get(ctx context.Context, prefix string, key string)
 	i.m.RLock()
 	defer i.m.RUnlock()
 
-	value, ok := i.data[prefix + key]
+	value, ok := i.data[prefix+key]
 
 	if !ok {
 		return nil, sgerrors.ErrNotFound
@@ -36,7 +36,7 @@ func (i *InMemoryRepository) Put(ctx context.Context, prefix string, key string,
 	i.m.Lock()
 	defer i.m.Unlock()
 
-	i.data[prefix + key] = value
+	i.data[prefix+key] = value
 	return nil
 }
 
@@ -44,8 +44,7 @@ func (i *InMemoryRepository) Delete(ctx context.Context, prefix string, key stri
 	i.m.Lock()
 	defer i.m.Unlock()
 
-
-	delete(i.data, prefix + key)
+	delete(i.data, prefix+key)
 	return nil
 }
 

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -1,8 +1,8 @@
 package memory
 
 import (
-	"testing"
 	"context"
+	"testing"
 
 	"github.com/supergiant/control/pkg/sgerrors"
 )
@@ -70,8 +70,8 @@ func TestInMemoryRepository_Put(t *testing.T) {
 func TestInMemoryRepository_GetAll(t *testing.T) {
 	repo := &InMemoryRepository{
 		data: map[string][]byte{
-			"prefixkeyone": []byte(`value1`),
-			"prefixkeytwo": []byte(`value2`),
+			"prefixkeyone":   []byte(`value1`),
+			"prefixkeytwo":   []byte(`value2`),
 			"prefixkeythree": []byte(`value3`),
 		},
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/supergiant/control/pkg/storage/memory"
-	"github.com/supergiant/control/pkg/storage/file"
+
 	"github.com/supergiant/control/pkg/storage/etcd"
+	"github.com/supergiant/control/pkg/storage/file"
+	"github.com/supergiant/control/pkg/storage/memory"
 )
 
 const (

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -21,12 +21,12 @@ func TestGetStorage(t *testing.T) {
 			reflect.TypeOf(&memory.InMemoryRepository{}),
 		},
 		{
-			"file.db",
+			"/tmp/file.db",
 			fileStorageType,
 			reflect.TypeOf(&file.FileRepository{}),
 		},
 		{
-			"file.db",
+			"/tmp/file.db",
 			etcdStorageType,
 			reflect.TypeOf(&etcd.ETCDRepository{}),
 		},

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/supergiant/control/pkg/clouds"
 	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/sgerrors"
@@ -418,6 +420,45 @@ func TestLoadCloudSpecificDataFromKube(t *testing.T) {
 
 		if !testCase.hasErr && err != nil {
 			t.Errorf("TC: %s: unexpected error %v", testCase.description, err)
+		}
+	}
+}
+
+func TestValidateAzureCredentials(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		creds       map[string]string
+		expectedErr error
+	}{
+		{
+			name:        "nil credentials map",
+			expectedErr: ErrInvalidCredentials,
+		},
+		{
+			name:        "empty credentials map",
+			creds:       map[string]string{},
+			expectedErr: ErrInvalidCredentials,
+		},
+		{
+			name: "invalid client id",
+			creds: map[string]string{
+				clouds.AzureTenantID: "1",
+			},
+			expectedErr: ErrInvalidCredentials,
+		},
+		{
+			name: "client credentials",
+			creds: map[string]string{
+				clouds.AzureTenantID:       "11",
+				clouds.AzureSubscriptionID: "33",
+				clouds.AzureClientID:       "22",
+				clouds.AzureClientSecret:   "clientsecret",
+			},
+		},
+	} {
+		err := validateAzureCredentials(tc.creds)
+		if errors.Cause(err) != tc.expectedErr {
+			t.Errorf("TC: %s: result='%v', expected='%v'", tc.name, errors.Cause(err), tc.expectedErr)
 		}
 	}
 }

--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/supergiant/control/pkg/workflows/statuses"
 	"github.com/supergiant/control/pkg/workflows/steps"
+	"github.com/supergiant/control/pkg/workflows/steps/authorizedKeys"
 	"github.com/supergiant/control/pkg/workflows/steps/certificates"
 	"github.com/supergiant/control/pkg/workflows/steps/clustercheck"
 	"github.com/supergiant/control/pkg/workflows/steps/cni"
@@ -22,7 +23,6 @@ import (
 	"github.com/supergiant/control/pkg/workflows/steps/ssh"
 	"github.com/supergiant/control/pkg/workflows/steps/storageclass"
 	"github.com/supergiant/control/pkg/workflows/steps/tiller"
-	"github.com/supergiant/control/pkg/workflows/steps/authorizedKeys"
 )
 
 // StepStatus aggregates data that is needed to track progress


### PR DESCRIPTION
Add ability to create Cloud Account for Azure with the [client credentials](https://github.com/Azure/azure-sdk-for-go#more-authentication-details) authentication model.

```
curl -XPOST  localhost:8080/v1/api/accounts -d'{
    "name":"test-azure",
    "provider":"azure",
    "credentials":{
        "azureTenantId":"tenant-id",
        "azureSubscriptionId":"subscription-id",
        "azureClientId":"client-id",
        "azureClientSecret":"client-secret"
    }
}'
```
