### PR TITLE
Fix CVE-2019-5736

### DIFF
--- a/templates/docker.sh.tpl
+++ b/templates/docker.sh.tpl
@@ -1,5 +1,5 @@
 #!/bin/sh
-# https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.06.0~ce-0~ubuntu_amd64.deb
+# https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_18.09.2~ce-0~ubuntu_amd64.deb
 
 DOCKER_VERSION={{ .Version }}
 UBUNTU_RELEASE={{ .ReleaseVersion }}


### PR DESCRIPTION
Update docker version to have fix for https://seclists.org/oss-sec/2019/q1/119