### PR TITLE
Add CreateResourceGroup step for Azure cloud provider

### DIFF
--- a/pkg/clouds/constants.go
+++ b/pkg/clouds/constants.go
@@ -62,8 +62,8 @@ const (
 
 	// Use client credentials auth model for azure.
 	// https://github.com/Azure/azure-sdk-for-go#more-authentication-details
-	AzureTenantID       = "azureTenantId"
-	AzureSubscriptionID = "azureSubscriptionId"
-	AzureClientID       = "azureClientId"
-	AzureClientSecret   = "azureClientSecret"
+	AzureTenantID       = "tenantId"
+	AzureSubscriptionID = "subscriptionId"
+	AzureClientID       = "clientId"
+	AzureClientSecret   = "clientSecret"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -116,6 +116,8 @@ func FillCloudAccountCredentials(ctx context.Context, cloudAccount *model.CloudA
 		return BindParams(cloudAccount.Credentials, &config.DigitalOceanConfig)
 	case clouds.GCE:
 		return BindParams(cloudAccount.Credentials, &config.GCEConfig)
+	case clouds.Azure:
+		return BindParams(cloudAccount.Credentials, &config.AzureConfig)
 	default:
 		return sgerrors.ErrUnknownProvider
 	}
@@ -160,17 +162,20 @@ func LoadCloudSpecificDataFromKube(k *model.Kube, config *steps.Config) error {
 		config.AWSConfig.MastersInstanceProfile = k.CloudSpec[clouds.AwsMasterInstanceProfile]
 		config.AWSConfig.NodesInstanceProfile = k.CloudSpec[clouds.AwsNodeInstanceProfile]
 		config.AWSConfig.ImageID = k.CloudSpec[clouds.AwsImageID]
-
 		config.Kube.SSHConfig.BootstrapPrivateKey = k.CloudSpec[clouds.AwsSshBootstrapPrivateKey]
 		config.Kube.SSHConfig.PublicKey = k.CloudSpec[clouds.AwsUserProvidedSshPublicKey]
-		return nil
+
 	case clouds.GCE:
 		config.GCEConfig.Region = k.Region
-		return nil
+
 	case clouds.DigitalOcean:
-		return nil
+
+	case clouds.Azure:
+		config.AzureConfig.Location = k.Region
+
+	default:
+		return errors.Wrapf(sgerrors.ErrUnsupportedProvider, "Load cloud specific data from kube %s", k.ID)
 	}
 
-	return errors.Wrapf(sgerrors.ErrUnsupportedProvider,
-		"Load cloud specific data from kube %s", k.ID)
+	return nil
 }

--- a/pkg/workflows/steps/azure/client.go
+++ b/pkg/workflows/steps/azure/client.go
@@ -1,0 +1,30 @@
+package azure
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+type Autorizerer interface {
+	Authorizer() (autorest.Authorizer, error)
+}
+
+func BaseClientFor(authorizer Autorizerer, subscriptionID string) (resources.BaseClient, error) {
+	token, err := authorizer.Authorizer()
+	if err != nil {
+		return resources.BaseClient{}, err
+	}
+	baseClient := resources.New(subscriptionID)
+	baseClient.Authorizer = token
+	return baseClient, nil
+}
+
+func toResourceGroupName(clusterID, clusterName string) string {
+	return fmt.Sprintf("sg-%s-%s", clusterName, clusterID)
+}
+
+func toStrPtr(s string) *string {
+	return &s
+}

--- a/pkg/workflows/steps/azure/create_group.go
+++ b/pkg/workflows/steps/azure/create_group.go
@@ -1,0 +1,69 @@
+package azure
+
+import (
+	"context"
+	"io"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/pkg/errors"
+
+	"github.com/supergiant/control/pkg/sgerrors"
+	"github.com/supergiant/control/pkg/workflows/steps"
+)
+
+const CreateGroupStepName = "CreateResourceGroup"
+
+type BaseClientFn func(authorizer Autorizerer, subscriptionID string) (resources.BaseClient, error)
+
+type CreateGroupStep struct {
+	baseClientFn BaseClientFn
+}
+
+func NewCreateInstanceStep() *CreateGroupStep {
+	return &CreateGroupStep{
+		baseClientFn: BaseClientFor,
+	}
+}
+
+func (s *CreateGroupStep) Run(ctx context.Context, output io.Writer, config *steps.Config) error {
+	if s.baseClientFn == nil {
+		return errors.Wrap(sgerrors.ErrNilEntity, "base client builder")
+	}
+
+	baseClient, err := s.baseClientFn(auth.ClientCredentialsConfig{
+		ClientID:     config.AzureConfig.ClientID,
+		ClientSecret: config.AzureConfig.ClientSecret,
+		TenantID:     config.AzureConfig.TenantID,
+	},
+		config.AzureConfig.SubscriptionID,
+	)
+	if err != nil {
+		return err
+	}
+
+	groupsClient := resources.GroupsClient{BaseClient: baseClient}
+	_, err = groupsClient.CreateOrUpdate(ctx, "", resources.Group{
+		Name:     toStrPtr(toResourceGroupName(config.ClusterID, config.ClusterName)),
+		Location: toStrPtr(config.AzureConfig.Location),
+		Tags:     map[string]*string{},
+	})
+
+	return errors.Wrap(err, "create resources group")
+}
+
+func (s *CreateGroupStep) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
+func (s *CreateGroupStep) Name() string {
+	return CreateGroupStepName
+}
+
+func (s *CreateGroupStep) Depends() []string {
+	return nil
+}
+
+func (s *CreateGroupStep) Description() string {
+	return "Azure: Create ResourceGroup"
+}

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -67,6 +67,15 @@ type GCEConfig struct {
 	InstanceGroup    string `json:"instanceGroup"`
 }
 
+type AzureConfig struct {
+	ClientID       string `json:"clientId"`
+	ClientSecret   string `json:"clientSecret"`
+	TenantID       string `json:"tenantId"`
+	SubscriptionID string `json:"subscriptionId"`
+
+	Location string `json:location`
+}
+
 type PacketConfig struct{}
 
 type OSConfig struct{}
@@ -221,6 +230,7 @@ type Config struct {
 	DigitalOceanConfig     DOConfig     `json:"digitalOceanConfig"`
 	AWSConfig              AWSConfig    `json:"awsConfig"`
 	GCEConfig              GCEConfig    `json:"gceConfig"`
+	AzureConfig            AzureConfig  `json:"azureConfig"`
 	OSConfig               OSConfig     `json:"osConfig"`
 	PacketConfig           PacketConfig `json:"packetConfig"`
 
@@ -290,6 +300,9 @@ func NewConfig(clusterName, clusterToken, cloudAccountName string, profile profi
 		GCEConfig: GCEConfig{
 			AvailabilityZone: profile.Zone,
 			ImageFamily:      "ubuntu-1604-lts",
+		},
+		AzureConfig: AzureConfig{
+			Location: profile.Region,
 		},
 		OSConfig:     OSConfig{},
 		PacketConfig: PacketConfig{},
@@ -417,6 +430,9 @@ func NewConfigFromKube(profile *profile.Profile, k *model.Kube) *Config {
 		},
 		GCEConfig: GCEConfig{
 			AvailabilityZone: profile.Zone,
+		},
+		AzureConfig: AzureConfig{
+			Location: profile.Region,
 		},
 		OSConfig:     OSConfig{},
 		PacketConfig: PacketConfig{},


### PR DESCRIPTION
Use [ResourceGroup](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups) to deal with cluster infrastructure as with a single resource on deletion process.