### PR TITLE
Add DeleteCluster step for Azure cloud

### DIFF
--- a/pkg/workflows/steps/azure/client.go
+++ b/pkg/workflows/steps/azure/client.go
@@ -1,16 +1,25 @@
 package azure
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 )
 
+var _ GroupsInterface = resources.GroupsClient{}
+
 type Autorizerer interface {
 	Authorizer() (autorest.Authorizer, error)
 }
 
+type GroupsInterface interface {
+	CreateOrUpdate(ctx context.Context, name string, grp resources.Group) (resources.Group, error)
+	Delete(ctx context.Context, name string) (resources.GroupsDeleteFuture, error)
+}
+
+// DEPRECATED
 func BaseClientFor(authorizer Autorizerer, subscriptionID string) (resources.BaseClient, error) {
 	token, err := authorizer.Authorizer()
 	if err != nil {
@@ -19,6 +28,16 @@ func BaseClientFor(authorizer Autorizerer, subscriptionID string) (resources.Bas
 	baseClient := resources.New(subscriptionID)
 	baseClient.Authorizer = token
 	return baseClient, nil
+}
+
+func GroupsClientFor(authorizer Autorizerer, subscriptionID string) (GroupsInterface, error) {
+	token, err := authorizer.Authorizer()
+	if err != nil {
+		return resources.GroupsClient{}, err
+	}
+	baseClient := resources.New(subscriptionID)
+	baseClient.Authorizer = token
+	return resources.GroupsClient{BaseClient: baseClient}, nil
 }
 
 func toResourceGroupName(clusterID, clusterName string) string {

--- a/pkg/workflows/steps/azure/client_test.go
+++ b/pkg/workflows/steps/azure/client_test.go
@@ -1,0 +1,22 @@
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+)
+
+type fakeGroupsClient struct {
+	GroupsInterface
+	createRes resources.Group
+	createErr error
+	deleteRes resources.GroupsDeleteFuture
+	deleteErr error
+}
+
+func (f fakeGroupsClient) CreateOrUpdate(ctx context.Context, name string, grp resources.Group) (resources.Group, error) {
+	return f.createRes, f.createErr
+}
+func (f fakeGroupsClient) Delete(ctx context.Context, name string) (resources.GroupsDeleteFuture, error) {
+	return f.deleteRes, f.deleteErr
+}

--- a/pkg/workflows/steps/azure/create_group_test.go
+++ b/pkg/workflows/steps/azure/create_group_test.go
@@ -1,0 +1,66 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/supergiant/control/pkg/sgerrors"
+	"github.com/supergiant/control/pkg/workflows/steps"
+)
+
+func TestCreateClusterStep(t *testing.T) {
+	s := NewCreateGroupStep()
+	require.NotNil(t, s.groupsClientFn, "groups client shouldn't be nil")
+
+	var nilStringSlice []string
+	require.Equal(t, nil, s.Rollback(context.Background(), nil, nil), "rollback not implemented")
+	require.Equal(t, nilStringSlice, s.Depends(), "depends not implemented")
+	require.Equal(t, CreateGroupStepName, s.Name(), "check step name")
+	require.Equal(t, "Azure: Create ResourceGroup", s.Description(), "check description")
+}
+
+func TestCreateClusterStep_Run(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		createGroup CreateGroupStep
+		expectedErr error
+	}{
+		{
+			name:        "nil groups client builder",
+			createGroup: CreateGroupStep{},
+			expectedErr: sgerrors.ErrNilEntity,
+		},
+		{
+			name: "build groups client error",
+			createGroup: CreateGroupStep{
+				groupsClientFn: func(authorizer Autorizerer, subscriptionID string) (GroupsInterface, error) {
+					return nil, errFake
+				},
+			},
+			expectedErr: errFake,
+		},
+		{
+			name: "delete cluster error",
+			createGroup: CreateGroupStep{
+				groupsClientFn: func(authorizer Autorizerer, subscriptionID string) (GroupsInterface, error) {
+					return fakeGroupsClient{createErr: errFake}, nil
+				},
+			},
+			expectedErr: errFake,
+		},
+		{
+			name: "success",
+			createGroup: CreateGroupStep{
+				groupsClientFn: func(authorizer Autorizerer, subscriptionID string) (GroupsInterface, error) {
+					return fakeGroupsClient{}, nil
+				},
+			},
+		},
+	} {
+		err := tc.createGroup.Run(context.Background(), nil, &steps.Config{})
+		require.Equalf(t, tc.expectedErr, errors.Cause(err), "TC: %s", tc.name)
+	}
+}

--- a/pkg/workflows/steps/azure/delete_cluster.go
+++ b/pkg/workflows/steps/azure/delete_cluster.go
@@ -1,0 +1,62 @@
+package azure
+
+import (
+	"context"
+	"io"
+
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/pkg/errors"
+
+	"github.com/supergiant/control/pkg/sgerrors"
+	"github.com/supergiant/control/pkg/workflows/steps"
+)
+
+const DeleteClusterStepName = "DeleteCluster"
+
+type DeleteClusterStep struct {
+	groupsClientFn GroupsClientFn
+}
+
+func NewDeleteClusterStep() *DeleteClusterStep {
+	return &DeleteClusterStep{
+		groupsClientFn: GroupsClientFor,
+	}
+}
+
+func (s DeleteClusterStep) Run(ctx context.Context, output io.Writer, config *steps.Config) error {
+	if s.groupsClientFn == nil {
+		return errors.Wrap(sgerrors.ErrNilEntity, "base client builder")
+	}
+
+	c, err := s.groupsClientFn(auth.ClientCredentialsConfig{
+		ClientID:     config.AzureConfig.ClientID,
+		ClientSecret: config.AzureConfig.ClientSecret,
+		TenantID:     config.AzureConfig.TenantID,
+	},
+		config.AzureConfig.SubscriptionID,
+	)
+	if err != nil {
+		return err
+	}
+
+	// All cluster resources have been added to the this resources group.
+	_, err = c.Delete(ctx, toResourceGroupName(config.ClusterID, config.ClusterName))
+
+	return errors.Wrap(err, "delete cluster: delete resource group")
+}
+
+func (s DeleteClusterStep) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
+func (s DeleteClusterStep) Name() string {
+	return DeleteClusterStepName
+}
+
+func (s DeleteClusterStep) Depends() []string {
+	return nil
+}
+
+func (s DeleteClusterStep) Description() string {
+	return "Azure: Delete Cluster"
+}

--- a/pkg/workflows/steps/azure/delete_cluster_test.go
+++ b/pkg/workflows/steps/azure/delete_cluster_test.go
@@ -1,0 +1,70 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/supergiant/control/pkg/sgerrors"
+	"github.com/supergiant/control/pkg/workflows/steps"
+)
+
+var (
+	errFake = errors.New("fake error")
+)
+
+func TestDeleteClusterStep(t *testing.T) {
+	s := NewDeleteClusterStep()
+	require.NotNil(t, s.groupsClientFn, "groups client shouldn't be nil")
+
+	var nilStringSlice []string
+	require.Equal(t, nil, s.Rollback(context.Background(), nil, nil), "rollback not implemented")
+	require.Equal(t, nilStringSlice, s.Depends(), "depends not implemented")
+	require.Equal(t, DeleteClusterStepName, s.Name(), "check step name")
+	require.Equal(t, "Azure: Delete Cluster", s.Description(), "check description")
+}
+
+func TestDeleteClusterStep_Run(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		deleteCluster DeleteClusterStep
+		expectedErr   error
+	}{
+		{
+			name:          "nil groups client builder",
+			deleteCluster: DeleteClusterStep{},
+			expectedErr:   sgerrors.ErrNilEntity,
+		},
+		{
+			name: "build groups client error",
+			deleteCluster: DeleteClusterStep{
+				groupsClientFn: func(authorizer Autorizerer, subscriptionID string) (GroupsInterface, error) {
+					return nil, errFake
+				},
+			},
+			expectedErr: errFake,
+		},
+		{
+			name: "delete cluster error",
+			deleteCluster: DeleteClusterStep{
+				groupsClientFn: func(authorizer Autorizerer, subscriptionID string) (GroupsInterface, error) {
+					return fakeGroupsClient{deleteErr: errFake}, nil
+				},
+			},
+			expectedErr: errFake,
+		},
+		{
+			name: "success",
+			deleteCluster: DeleteClusterStep{
+				groupsClientFn: func(authorizer Autorizerer, subscriptionID string) (GroupsInterface, error) {
+					return fakeGroupsClient{}, nil
+				},
+			},
+		},
+	} {
+		err := tc.deleteCluster.Run(context.Background(), nil, &steps.Config{})
+		require.Equalf(t, tc.expectedErr, errors.Cause(err), "TC: %s", tc.name)
+	}
+}

--- a/pkg/workflows/steps/certificates/certificates.go
+++ b/pkg/workflows/steps/certificates/certificates.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 
 	tm "github.com/supergiant/control/pkg/templatemanager"
-	"github.com/supergiant/control/pkg/workflows/util"
 	"github.com/supergiant/control/pkg/workflows/steps"
+	"github.com/supergiant/control/pkg/workflows/util"
 )
 
 const StepName = "certificates"


### PR DESCRIPTION
Control adds all cluster resources to a particular resources group. Delete the group to remove a cluster infrastructure.