### PR TITLE
Truncate Long Account Names

### DIFF
--- a/cmd/ui/assets/src/app/clusters/cluster/cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/cluster/cluster.component.html
@@ -196,7 +196,8 @@
         </div>
         <div class="values">
           <span>{{ kube.K8SVersion }}</span>
-          <span>{{ kube.accountName }}</span>
+          <!-- TODO: do this in component or service -->
+          <span>{{ (kube.accountName.length>8)? (kube.accountName | slice:0:8)+'...':(kube.accountName) }}</span>
           <span>{{ kube.arch }}</span>
           <span>{{ kube.operatingSystem }}</span>
         </div>

--- a/cmd/ui/assets/src/app/dashboard/cluster-table/cluster-table.component.html
+++ b/cmd/ui/assets/src/app/dashboard/cluster-table/cluster-table.component.html
@@ -20,7 +20,8 @@
 
         <ng-container matColumnDef="accountName">
           <mat-header-cell *matHeaderCellDef>Account</mat-header-cell>
-          <mat-cell *matCellDef="let cluster">{{ cluster.accountName }}</mat-cell>
+          <!-- TODO: move this to component or service -->
+          <mat-cell *matCellDef="let cluster">{{ (cluster.accountName.length>8)? (cluster.accountName | slice:0:8)+'...':(cluster.accountName) }}</mat-cell>
         </ng-container>
 
         <ng-container matColumnDef="cpu">


### PR DESCRIPTION
* truncate cloud account name on cluster details at 8 char

* fix for https://github.com/supergiant/control/issues/1289