### PR TITLE
App Configure Editor

### DIFF
--- a/cmd/ui/assets/src/app/features/app-store/app-details/confure/configure.component.html
+++ b/cmd/ui/assets/src/app/features/app-store/app-details/confure/configure.component.html
@@ -6,7 +6,7 @@
        [autoUpdateContent]="true"
        [durationBeforeCallback]="1000"
        (textChanged)="onChange($event)"
-       style="min-height: 650px; width:100%; overflow: auto;"></div>
+       style="height: 450px; width:100%; overflow: auto;"></div>
 </mat-dialog-content>
 <mat-dialog-actions>
   <button class="btn-secondary"


### PR DESCRIPTION
* when configuring an app in the service catalog, the editor height and
modal height interacted in a confusing way. No more.