### PR TITLE
Fix Azure region finder

### DIFF
--- a/pkg/account/region_finder.go
+++ b/pkg/account/region_finder.go
@@ -507,6 +507,7 @@ func (f AzureFinder) toRegionSizes(locations []subscription.Location, machineSiz
 
 		sizes[to.String(vm.Name)] = vm
 		for _, l := range to.StringSlice(vm.Locations) {
+			l = strings.ToLower(l) // could be camelCase, for instance SouthAfricaWest
 			if regionSizes[l] == nil {
 				regionSizes[l] = strset.New()
 			}


### PR DESCRIPTION
`subscription` client returns region names in lower case while  `skus` client uses as lower case as camel case for it. So region finder returns empty sizes list for some regions. This PR fixes it.