### PR TITLE
Fix template for the add_authorized_keys step

### DIFF
--- a/templates/add_authorized_keys.tpl
+++ b/templates/add_authorized_keys.tpl
@@ -3,7 +3,7 @@ sudo chmod 700 /root/.ssh
 sudo touch /root/.ssh/authorized_keys
 sudo chmod 600 /root/.ssh/authorized_keys
 
-sudo bash -c "cat << EOF > /root/.ssh/authorized_keys
+sudo bash -c "cat << EOF >> /root/.ssh/authorized_keys
 {{ .PublicKey }}
 EOF"
 


### PR DESCRIPTION
<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [x] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [ ] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

With the https://github.com/supergiant/control/pull/1369/files#diff-ce592517289bd2f9d474a0ac11175098L5 change control overwrites a bootstrap ssh public key with a user public key and then can't login to machine for cluster provisioning. This PR fixes it.

<!-- Specify the GitHub issue this PR fixes, if any. -->

### Additional Details?

<!-- Add important details of the PR below, or put "NONE." -->
<!-- Includes actions users must take to use the changes. -->

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [ ] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
