### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=builder /go/bin/supergiant /bin/supergiant
 COPY --from=builder /go/src/github.com/supergiant/control/templates /etc/supergiant/templates
 EXPOSE 60200-60250
 
-ENTRYPOINT ["/bin/supergiant", "-storage-uri", "/var/run/supergiant/supergiant.db"]
+ENTRYPOINT ["/bin/supergiant", "-storage-uri", "supergiant.db"]


### PR DESCRIPTION
<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [x] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [ ] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

Control fails to create the `/var/run/supergiant/supergiant.db` file because there is no `/var/..` directory. This PR fixes it.
```
$  docker run --rm supergiant/control                           
time="2019-04-17T17:00:46Z" level=info msg="configuration: {Port:8080 Addr:0.0.0.0 StorageMode:file StorageURI:/var/run/supergiant/supergiant.db TemplatesDir:/etc/supergiant/templates/ SpawnInterval:5s ReadTimeout:20s WriteTimeout:10s IdleTimeout:2m0s PprofListenStr: ProxiesPortRange:{From:60200 To:60250} Version:unstable}"
time="2019-04-17T17:00:46Z" level=fatal msg="broken configuration: get storage type file uri /var/run/supergiant/supergiant.db: open /var/run/supergiant/supergiant.db: no such file or directory"
```

<!-- Specify the GitHub issue this PR fixes, if any. -->

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [ ] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
