### PR TITLE
Specify API port when join controlplane

### DIFF
--- a/templates/kubeadm.sh.tpl
+++ b/templates/kubeadm.sh.tpl
@@ -24,8 +24,9 @@ HOSTNAME="$(hostname -f)"
 
 {{if .IsMaster }}
 
-{{ if .IsBootstrap }}
 sudo mkdir -p /etc/supergiant
+
+{{ if .IsBootstrap }}
 
 sudo bash -c "cat << EOF > /etc/supergiant/kubeadm.conf
 ---
@@ -71,10 +72,27 @@ sudo kubeadm init --ignore-preflight-errors=NumCPU \
 --config=/etc/supergiant/kubeadm.conf
 {{ else }}
 
+sudo bash -c "cat << EOF > /etc/supergiant/kubeadm.conf
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: JoinConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    {{ if .Provider }}cloud-provider: {{ .Provider }}{{ end }}
+discovery:
+  bootstrapToken:
+    token: {{ .Token }}
+    apiServerEndpoint: {{ .InternalDNSName }}:443
+    unsafeSkipCAVerification: true
+controlPlane:
+  localAPIEndpoint:
+    advertiseAddress: {{ .AdvertiseAddress }}
+    bindPort: 443
+EOF"
+
 sudo kubeadm config images pull
-sudo kubeadm join --ignore-preflight-errors=NumCPU {{ .InternalDNSName }}:443 --token {{ .Token }} \
+sudo kubeadm join --ignore-preflight-errors=NumCPU {{ .InternalDNSName }}:443 \
 --node-name ${HOSTNAME} \
---discovery-token-unsafe-skip-ca-verification --experimental-control-plane
+--config=/etc/supergiant/kubeadm.conf
 {{ end }}
 
 sudo mkdir -p $HOME/.kube


### PR DESCRIPTION
- [x] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [ ] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

We need to specify port 443 when join new controlplane
node because it uses 6443 by default

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

Example: Introduces a new cloud provider for provisioning and managing kubes on GCE, due to popular demand.

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [x] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
