### PR TITLE
Visual redesign of provisioning wizard

### DIFF
--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
@@ -1,10 +1,9 @@
 <div class="new-clusters-wrapper">
-  <h1>Create Kubernetes Cluster</h1>
+  <h1>Create a Kubernetes Cluster</h1>
 
   <mat-horizontal-stepper *ngIf="(availableCloudAccounts$ | async)?.length > 0"
                           [linear]="true"
                           #stepper>
-
     <!--
     TODO:
       - material considers a step "done" when all fields are completed and *NOT* editable;
@@ -12,10 +11,12 @@
       - we should consider manually overriding the icons to remove the non-editable requirement for "done" state
       - https://github.com/angular/material2/issues/8997
     -->
-    <mat-step label="Name and Cloud Account"
-              [stepControl]="nameAndCloudAccountForm">
-      <div class="name-and-cloud-account">
-        <form [formGroup]="nameAndCloudAccountForm">
+
+    <mat-step label="Cluster Configuration"
+              [stepControl]="clusterConfig">
+      <form [formGroup]="clusterConfig"
+            class="cluster-config-step">
+        <div class="input-group">
           <mat-form-field>
             <input matInput
                    type="text"
@@ -37,46 +38,10 @@
                           [value]="account">{{ account.name }}</mat-option>
             </mat-select>
           </mat-form-field>
-
-          <div *ngIf="name.invalid">
-            <p *ngIf="name.errors.nonUniqueName"
-               class="warning">Cluster name must be unique</p>
-            <p *ngIf="name.errors.maxlength"
-               class="warning">Cluster name must be less than 12 characters</p>
-            <p *ngIf="name.errors.pattern"
-               class="warning">Cluster name must start with a-z or A-Z, and can only contain a-z, A-Z, 0-9, and -
-                               characters</p>
-          </div>
-        </form>
-
-        <div class="step-actions">
-          <button mat-raised-button
-                  class="secondary"
-                  matStepperNext>NEXT
-          </button>
         </div>
-      </div>
-    </mat-step>
 
-    <mat-step label="Cluster Configuration"
-              [stepControl]="clusterConfig">
-      <form [formGroup]="clusterConfig"
-            class="cluster-and-provider-config">
         <div class="input-group">
-          <mat-form-field>
-            <mat-select placeholder="K8s Version"
-                        formControlName="K8sVersion"
-                        required>
-              <mat-option *ngFor="let k of clusterOptions.K8sVersions"
-                          [value]="k">{{ k }}</mat-option>
-            </mat-select>
-            <mat-hint align="end">Check out k8s
-              <a href="https://kubernetes.io/docs/setup/release/notes/"
-                 target="_blank">release notes</a>
-            </mat-hint>
-          </mat-form-field>
-
-          <mat-form-field>
+            <mat-form-field>
             <mat-select placeholder="Network Provider"
                         formControlName="networkProvider"
                         required>
@@ -90,56 +55,15 @@
           </mat-form-field>
 
           <mat-form-field>
-            <mat-select placeholder="Helm Version"
-                        formControlName="helmVersion"
+            <mat-select placeholder="K8s Version"
+                        formControlName="K8sVersion"
                         required>
-              <mat-option *ngFor="let h of clusterOptions.helmVersions"
-                          [value]="h">{{ h }}</mat-option>
+              <mat-option *ngFor="let k of clusterOptions.K8sVersions"
+                          [value]="k">{{ k }}</mat-option>
             </mat-select>
-            <mat-hint align="end">What is
-              <a href="https://docs.helm.sh/helm/"
-                 target="_blank">Helm</a>?
-            </mat-hint>
-          </mat-form-field>
-        </div>
-
-        <div class="input-group">
-          <mat-form-field>
-            <mat-select placeholder="Docker Version"
-                        formControlName="dockerVersion"
-                        required>
-              <mat-option *ngFor="let d of clusterOptions.dockerVersions"
-                          [value]="d">{{ d }}</mat-option>
-            </mat-select>
-            <mat-hint align="end">Check out Docker
-              <a href="https://docs.docker.com/release-notes/"
+            <mat-hint align="end">Check out k8s
+              <a href="https://kubernetes.io/docs/setup/release/notes/"
                  target="_blank">release notes</a>
-            </mat-hint>
-          </mat-form-field>
-
-          <mat-form-field>
-            <mat-select placeholder="Ubuntu Version"
-                        formControlName="ubuntuVersion"
-                        required>
-              <mat-option *ngFor="let u of clusterOptions.ubuntuVersions"
-                          [value]="u">{{ u }}</mat-option>
-            </mat-select>
-            <mat-hint align="end">Check out
-              <a href="https://www.ubuntu.com/"
-                 target="_blank">Ubuntu</a>
-            </mat-hint>
-          </mat-form-field>
-
-          <mat-form-field>
-            <mat-select placeholder="Network Type"
-                        formControlName="networkType"
-                        required>
-              <mat-option *ngFor="let n of clusterOptions.networkTypes"
-                          [value]="n">{{ n }}</mat-option>
-            </mat-select>
-            <mat-hint align="end">Read more about
-              <a href="https://github.com/coreos/flannel/blob/master/Documentation/backends.md"
-                 target="_blank">network types</a>
             </mat-hint>
           </mat-form-field>
         </div>
@@ -158,30 +82,10 @@
           </mat-form-field>
 
           <mat-form-field>
-            <mat-select placeholder="Operating System"
-                        formControlName="operatingSystem"
-                        required>
-              <mat-option *ngFor="let os of clusterOptions.operatingSystems"
-                          [value]="os">{{ os }}</mat-option>
-            </mat-select>
-          </mat-form-field>
-
-          <mat-form-field>
-            <mat-select placeholder="Arch"
-                        formControlName="arch"
-                        required>
-              <mat-option *ngFor="let a of clusterOptions.archs"
-                          [value]="a">{{ a }}</mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-        
-        <div class="input-group">
-          <mat-form-field>
             <textarea (blur)="putExposedAddressesInArray($event)"
                       cdkTextareaAutosize
-                      cdkAutosizeMinRows="9"
-                      cdkAutosizeMaxRows="9"
+                      cdkAutosizeMinRows="1"
+                      cdkAutosizeMaxRows="6"
                       matInput
                       formControlName="exposedAddresses"
                       placeholder="IP Whitelist"></textarea>
@@ -191,8 +95,17 @@
             </mat-hint>
           </mat-form-field>
         </div>
-
       </form>
+
+      <div *ngIf="name.invalid">
+        <p *ngIf="name.errors.nonUniqueName"
+           class="warning">Cluster name must be unique</p>
+        <p *ngIf="name.errors.maxlength"
+           class="warning">Cluster name must be less than 12 characters</p>
+        <p *ngIf="name.errors.pattern"
+           class="warning">Cluster name must start with a-z or A-Z, and can only contain a-z, A-Z, 0-9, and -
+                           characters</p>
+      </div>
 
       <div *ngIf="cidr.invalid">
         <p *ngIf="cidr.errors.invalidCidr"
@@ -206,11 +119,7 @@
 
       <div class="step-actions">
         <button mat-raised-button
-                class="secondary"
-                matStepperPrevious>BACK
-        </button>
-        <button mat-raised-button
-                class="secondary"
+                color="primary"
                 matStepperNext>NEXT
         </button>
       </div>
@@ -221,7 +130,7 @@
       <!-- digital ocean -->
       <ng-container *ngIf="selectedCloudAccount?.provider == 'digitalocean'">
         <form [formGroup]="providerConfig"
-              class="cluster-and-provider-config">
+              class="provider-config-step">
           <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
             <mat-select placeholder="Select a Region"
                         formControlName="region"
@@ -245,7 +154,7 @@
       <!-- aws -->
       <ng-container *ngIf="selectedCloudAccount?.provider == 'aws'">
         <form [formGroup]="providerConfig"
-              class="cluster-and-provider-config">
+              class="provider-config-step">
           <div class="input-group">
             <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
               <mat-select placeholder="Select a Region"
@@ -272,32 +181,6 @@
                      placeholder="VPC CIDR"
                      required>
             </mat-form-field>
-
-            <mat-form-field>
-              <input matInput
-                     type="text"
-                     formControlName="vpcId"
-                     placeholder="VPC ID">
-              <mat-hint align="end">Leaving this blank will create a new one</mat-hint>
-            </mat-form-field>
-          </div>
-
-          <div class="input-group">
-            <mat-form-field>
-              <input matInput
-                     type="text"
-                     formControlName="mastersSecurityGroupId"
-                     placeholder="Master's Security Group ID">
-              <mat-hint align="end">Leaving this blank will create a new one</mat-hint>
-            </mat-form-field>
-
-            <mat-form-field>
-              <input matInput
-                     type="text"
-                     formControlName="nodesSecurityGroupId"
-                     placeholder="Node's Security Group ID">
-              <mat-hint align="end">Leaving this blank will create a new one</mat-hint>
-            </mat-form-field>
           </div>
 
           <div class="input-group public-key-wrapper">
@@ -323,7 +206,7 @@
       <!-- gce -->
       <ng-container *ngIf="selectedCloudAccount?.provider == 'gce'">
         <form [formGroup]="providerConfig"
-              class="cluster-and-provider-config">
+              class="provider-config-step">
           <div class="input-group">
             <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
               <mat-select placeholder="Select a Region"
@@ -366,7 +249,7 @@
       <!-- azure -->
       <ng-container *ngIf="selectedCloudAccount?.provider == 'azure'">
         <form [formGroup]="providerConfig"
-              class="cluster-and-provider-config">
+              class="provider-config-step">
           <div class="input-group">
             <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
               <mat-select placeholder="Select a Region"
@@ -432,7 +315,7 @@
                 matStepperPrevious>BACK
         </button>
         <button mat-raised-button
-                class="secondary"
+                color="primary"
                 matStepperNext>NEXT
         </button>
       </div>
@@ -445,7 +328,7 @@
         <ng-container *ngIf="selectedCloudAccount?.provider == 'digitalocean'">
           <div class="machine"
                *ngFor="let m of machines; let idx = index">
-            <mat-form-field class="type">
+            <mat-form-field>
               <mat-select #selectedMachineType
                           placeholder="Machine Type (size)"
                           id="m.machineType"
@@ -469,7 +352,7 @@
               </mat-hint>
             </mat-form-field>
 
-            <mat-form-field class="role">
+            <mat-form-field>
               <mat-select placeholder="Role"
                           [(value)]="m.role"
                           (selectionChange)="validateMachineConfig(m)">
@@ -670,6 +553,7 @@
           </div>
         </ng-container>
 
+        <!-- azure -->
         <ng-container *ngIf="selectedCloudAccount?.provider == 'azure'">
           <div class="machine"
                *ngFor="let m of machines; let idx = index">
@@ -747,7 +631,7 @@
                 matStepperPrevious>BACK
         </button>
         <button mat-raised-button
-                class="secondary"
+                color="primary"
                 (click)="nextStep()">NEXT
         </button>
       </div>
@@ -757,23 +641,13 @@
       <div class="review-wrapper">
         <h1>{{ clusterName }}</h1>
         <div class="steps">
-          <div class="cloud-account">
-            <h3>CLOUD ACCOUNT</h3>
-            <p>{{ selectedCloudAccount?.name }} ({{ selectedCloudAccount?.provider }})</p>
-          </div>
-
           <div class="cluster">
             <h3>CLUSTER DETAILS</h3>
             <div>
-              <p><span class="label">K8s VERSION:</span> {{ clusterConfig.value.K8sVersion }}</p>
+              <p><span class="label">CLOUD ACCOUNT:</span> {{ selectedCloudAccount?.name }} ({{ selectedCloudAccount?.provider }})</p>
               <p><span class="label">NETWORK PROVIDER:</span> {{ clusterConfig.value.networkProvider }}</p>
-              <p><span class="label">HELM VERSION:</span> {{ clusterConfig.value.helmVersion }}</p>
-              <p><span class="label">DOCKER VERSION:</span> {{ clusterConfig.value.dockerVersion }}</p>
-              <p><span class="label">UBUNTU VERSION:</span> {{ clusterConfig.value.ubuntuVersion }}</p>
-              <p><span class="label">NETWORK TYPE:</span> {{ clusterConfig.value.networkType }}</p>
+              <p><span class="label">K8s VERSION:</span> {{ clusterConfig.value.K8sVersion }}</p>
               <p><span class="label">CIDR:</span> {{ clusterConfig.value.cidr }}</p>
-              <p><span class="label">OPERATING SYSTEM:</span> {{ clusterConfig.value.operatingSystem }}</p>
-              <p><span class="label">ARCH:</span> {{ clusterConfig.value.arch }}</p>
               <p><span class="label">IP WHITELIST:</span>
                 <div *ngFor="let e of exposedAddressesArray">
                   {{e}}
@@ -791,11 +665,7 @@
             <!-- aws -->
             <div *ngIf="selectedCloudAccount?.provider == 'aws'">
               <p><span class="label">REGION: </span> {{ providerConfig.value.region.name }}</p>
-              <p><span class="label">VPC ID: </span>{{ providerConfig.value.vpcId }}</p>
               <p><span class="label">VPC CIDR: </span> {{ providerConfig.value.vpcCidr }}</p>
-              <p><span class="label">SUBNET ID: </span>{{ providerConfig.value.subnetId }}</p>
-              <p><span class="label">MASTERS SEC. GROUP ID: </span>{{ providerConfig.value.mastersSecurityGroupId }}</p>
-              <p><span class="label">NODES SEC. GROUP ID: </span>{{ providerConfig.value.nodesSecurityGroupId }}</p>
             </div>
 
             <!-- gce -->
@@ -827,8 +697,7 @@
 
                 <!-- gce -->
                 <ng-container *ngIf="selectedCloudAccount?.provider == 'gce'">
-                  <p class="label machine-label">{{ m.qty }} x {{ m.machineType }} ({{ m.role }}
-                                                             ): {{ m.availabilityZone }}</p>
+                  <p class="label machine-label">{{ m.qty }} x {{ m.machineType }} ({{ m.role }})</p>
                   <p class="availability-zone">{{ m.availabilityZone }}</p>
                 </ng-container>
 

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
@@ -11,6 +11,10 @@
     margin-bottom: 10px;
   }
 
+  .mat-form-field-required-marker {
+    color: #D10088;
+  }
+
   .warning {
     color: #f44336;
     font-weight: 300;
@@ -19,7 +23,34 @@
 
   .mat-stepper-horizontal {
     background-color: rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(255, 255, 255, 0.25);
+
+    .mat-step-label {
+      font-weight: 300;
+    }
+
+    .mat-step-label.mat-step-label-active {
+      font-size: 16px;
+      color: #D10088;
+    }
+
+    .mat-step-label-selected {
+      font-weight: 500;
+    }
+
+    .mat-step-icon {
+      font-family: Montserrat, sans-serif;
+      font-size: 17px;
+      font-weight: 500;
+      color: black;
+      background-image: linear-gradient(315deg, #8721ff, #ff457e);
+    }
+
+    .mat-step-icon-not-touched {
+      font-family: Montserrat, sans-serif;
+      font-size: 17px;
+      font-weight: 500;
+      color: black;
+    }
 
     .step-actions {
       display: flex;
@@ -27,6 +58,7 @@
 
       button {
         margin-left: 24px;
+        min-width: 100px;
 
         &:nth-of-type(1) {
           margin-left: 0px;
@@ -38,17 +70,23 @@
       }
     }
 
-    .name-and-cloud-account {
+    .cluster-config-step {
       display: flex;
-      flex-direction: column;
-      width: 250px;
+      justify-content: space-between;
 
-      .mat-form-field {
+      .input-group {
+        display: flex;
+        flex-direction: column;
+        margin-left: 100px;
         width: 100%;
+
+        &:nth-of-type(1) {
+          margin-left: 0px;
+        }
       }
     }
 
-    .cluster-and-provider-config {
+    .provider-config-step {
       display: flex;
       justify-content: flex-start;
 
@@ -56,7 +94,7 @@
         display: flex;
         flex-direction: column;
         margin-left: 100px;
-        width: 250px;
+        width: 290px;
 
         &:nth-of-type(1) {
           margin-left: 0px;
@@ -65,14 +103,15 @@
         .regionsLoading {
           animation: loading 1s infinite;
         }
-
-        .azsLoading {
-          animation: loading 1s infinite;
-        }
       }
 
       .public-key-wrapper {
-        width: 400px;
+        width: 900px;
+        
+        &::-webkit-scrollbar {
+          width: 0px;
+          height: 0px;
+        }
       }
     }
 
@@ -86,18 +125,11 @@
 
         .mat-form-field {
           margin-right: 24px;
-        }
-
-        .type {
-          width: 240px;
+          width: 290px;
         }
 
         .machinesLoading {
           animation: loading 1s infinite;
-        }
-
-        .role {
-          width: 123px;
         }
 
         .quantity {
@@ -105,12 +137,13 @@
         }
 
         .delete {
-          background: url(/assets/img/delete.svg) no-repeat;
+          background: url(/assets/img/delete-pink.svg) no-repeat;
           background-size: 100% 100%;
           background-position: center;
           cursor: pointer;
           display: inline-block;
           margin: auto 0;
+          margin-top: 18px;
           height: 25px;
           width: 25px;
 
@@ -129,6 +162,10 @@
             color: $sg-pink;
           }
         }
+
+        .azsLoading {
+          animation: loading 1s infinite;
+        }
       }
 
       .add-machines {
@@ -141,7 +178,7 @@
         }
 
         .plus {
-          background: url(/assets/img/plus.svg) no-repeat;
+          background: url(/assets/img/plus-pink.svg) no-repeat;
           background-size: 100% 100%;
           background-position: center;
           margin: auto 0;
@@ -167,10 +204,15 @@
 
       .steps {
         display: flex;
-        justify-content: space-around;
+        justify-content: center;
+
+        .provider {
+          margin-left: 100px;
+          margin-right: 100px;
+        }
 
         .label {
-          color: #d10088;
+          color: #D10088;
           font-family: "Montserrat", sans-serif;
           font-size: 14px;
         }

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
@@ -23,6 +23,7 @@
 
   .mat-stepper-horizontal {
     background-color: rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.25);
 
     .mat-step-label {
       font-weight: 300;
@@ -107,11 +108,6 @@
 
       .public-key-wrapper {
         width: 900px;
-        
-        &::-webkit-scrollbar {
-          width: 0px;
-          height: 0px;
-        }
       }
     }
 


### PR DESCRIPTION
* reduced five steps of cluster provisioning to four (removed NameAndCloudAccount)
* removed single-option drop-down fields from UI
* removed three AWS-specific fields from UI _and_ from what is passed to the back-end:
   - VPC ID
   - Master's Security Group ID
   - Node's Security Group ID
* made Next buttons, required icon (*), and icons on Machine Config step pink
* changed formatting of mat-step labels (top portion of stepper)
* made most fields wider to take up more space across screen
* restored azsLoading animation to correct step
* altered the way UI packages up data to send to back-end
* resolves card S20-644, except for + / - icons to control Quantity on Machine Config step (that task is still outstanding)

<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [ ] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [x] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

Example: Introduces a new cloud provider for provisioning and managing kubes on GCE, due to popular demand.

<!-- Specify the GitHub issue this PR fixes, if any. -->

Example: Fixes #78, #89, #123

### Additional Details?

<!-- Add important details of the PR below, or put "NONE." -->
<!-- Includes actions users must take to use the changes. -->

Example: In order to take advantage of this new feature, users will need to restart SG Control with the `gce` provider option added to the `providers` flag: `--providers=gce,aws,etc.` Otherwise, functionality is not changed.

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [x] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
