### PR TITLE
Set autofocus on drop-down filters and lock filters into place

### DIFF
--- a/cmd/ui/assets/src/app/callback.pipe.ts
+++ b/cmd/ui/assets/src/app/callback.pipe.ts
@@ -2,13 +2,24 @@ import { PipeTransform, Pipe } from '@angular/core';
 
 @Pipe({
   name: 'callback',
-  pure: false
+  pure: true
 })
 export class CallbackPipe implements PipeTransform {
-  transform(items: any[], callback: (item: any) => boolean): any {
-    if (!items || !callback) {
+  transform(items: any[], filter: string) {
+
+    if (!items || !filter) {
       return items;
     }
-    return items.filter(item => callback(item));
+
+    let filteredItems = [];
+
+    for(let i of items){
+    	let itemString = String(i).toLowerCase();
+    	if(itemString.includes(filter.toLowerCase())){
+    		filteredItems.push(i);
+    	}
+    }
+
+    return filteredItems;
   }
 }

--- a/cmd/ui/assets/src/app/clusters/cluster/add-node/add-node.component.html
+++ b/cmd/ui/assets/src/app/clusters/cluster/add-node/add-node.component.html
@@ -22,15 +22,16 @@
       <mat-select placeholder="Machine Type (size)"
                   [disabled]="!m.availabilityZone && ((provider$ | async)  === 'aws' || (provider$ | async)  === 'gce')"
                   [(value)]="m.machineType"
-                  (openedChange)="machineTypesFilter = ''"
+                  (openedChange)="[m.filter = '', machineFilter.focus()]"
                   (selectionChange)="checkAndSetValidMachineConfig()">
-        <input class="machine-types-filter"
-               matInput
-               type="text"
-               placeholder="Filter machines..."
-               [(ngModel)]="machineTypesFilter"
-               autofocus>
-      <mat-option *ngFor="let type of (machineSizes$ | async) | callback: filterCallback"
+        <div class="sticky-filter-wrapper">
+          <input #machineFilter
+                 matInput
+                 type="text"
+                 placeholder="Filter machines..."
+                 [(ngModel)]="m.filter">
+        </div>
+      <mat-option *ngFor="let type of (machineSizes$ | async) | callback: m.filter"
                   [value]="type">{{ type }}</mat-option>
       </mat-select>
       </mat-form-field>

--- a/cmd/ui/assets/src/app/clusters/cluster/add-node/add-node.component.scss
+++ b/cmd/ui/assets/src/app/clusters/cluster/add-node/add-node.component.scss
@@ -128,10 +128,11 @@
   }
 }
 
-::ng-deep .mat-select-content {
-
-  .machine-types-filter {
-    position: relative;
-    padding: 10px !important;
-  }
+.sticky-filter-wrapper {
+  position: sticky;
+  padding: 10px !important;
+  z-index: 100;
+  top: 0;
+  background-color: #424242;
+  border-bottom: 1px solid rgba(255,255,255,0.25);
 }

--- a/cmd/ui/assets/src/app/clusters/cluster/add-node/add-node.component.ts
+++ b/cmd/ui/assets/src/app/clusters/cluster/add-node/add-node.component.ts
@@ -42,6 +42,7 @@ export class AddNodeComponent implements OnInit, OnDestroy {
     role: 'Node',
     qty: 1,
     availabilityZone: '',
+    filter: '',
   }];
 
   machineSizes$: Observable<any>;
@@ -58,7 +59,6 @@ export class AddNodeComponent implements OnInit, OnDestroy {
   availabilityZones: string[];
   selectedAZSubj: Subject<string>;
   isLoadingMachineTypes: boolean = true;
-  machineTypesFilter = '';
 
   constructor(
     private supergiant: Supergiant,
@@ -301,13 +301,5 @@ export class AddNodeComponent implements OnInit, OnDestroy {
       this.displayMachineConfigError = true;
     }
   }
-
-  filterCallback = (val) => {
-    if (this.machineTypesFilter === '') {
-      return val;
-    }
-
-    return val.indexOf(this.machineTypesFilter) > -1;
-  };
 
 }

--- a/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.html
@@ -51,17 +51,18 @@
           <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
             <mat-select placeholder="Select a Region"
                         formControlName="region"
-                        (openedChange)="regionsFilter = ''"
+                        (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                         required>
-              <input class="select-filter"
-                     matInput
-                     type="text"
-                     placeholder="Filter regions..."
-                     [(ngModel)]="regionsFilter"
-                     [ngModelOptions]="{ standalone: true }"
-                     autofocus>
-              <mat-option *ngFor="let r of availableRegions?.regions | callback: regionsFilterCallback"
-                          [value]="r">{{ r.name }}</mat-option>
+              <div class="sticky-filter-wrapper">
+                <input #regionFilter
+                       matInput
+                       type="text"
+                       placeholder="Filter regions..."
+                       [(ngModel)]="regionsFilter"
+                       [ngModelOptions]="{ standalone: true }">
+              </div>
+              <mat-option *ngFor="let r of availableRegionNames | callback: regionsFilter"
+                          [value]="r">{{ r }}</mat-option>
             </mat-select>
           </mat-form-field>
 

--- a/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.scss
+++ b/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.scss
@@ -95,9 +95,13 @@
   }
 }
 
-.select-filter {
-  position: relative;
+.sticky-filter-wrapper {
+  position: sticky;
   padding: 10px !important;
+  z-index: 100;
+  top: 0;
+  background-color: #424242;
+  border-bottom: 1px solid rgba(255,255,255,0.25);
 }
 
 .mat-spinner {

--- a/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.ts
+++ b/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.ts
@@ -26,6 +26,7 @@ export class ImportClusterComponent implements OnInit {
   public availableRegions: Array<CloudAccount>;
   public importForm: FormGroup;
   public unavailableClusterNames = new Set;
+  availableRegionNames: Array<string>;
   regionsFilter = '';
   regionsLoading = false;
   importing = false;
@@ -96,7 +97,7 @@ export class ImportClusterComponent implements OnInit {
         privateKey: form.value.privateKey,
         profile: {
           id: clusterId,
-          region: form.value.region.name,
+          region: form.value.region,
           arch: form.value.arch,
           operatingSystem: "linux",
           ubuntuVersion: "xenial",
@@ -141,17 +142,10 @@ export class ImportClusterComponent implements OnInit {
     )
 
     regions$.subscribe(res => {
-      this.availableRegions = res;
+      this.availableRegions = res.regions;
+      this.availableRegionNames = this.availableRegions.map(n => n.name);
       this.regionsLoading = false;
     });
-  }
-
-  regionsFilterCallback = (val) => {
-    if (this.regionsFilter === '') {
-      return val.name;
-    }
-
-    return val.name.toLowerCase().indexOf(this.regionsFilter.toLowerCase()) > -1;
   }
 
   error(err) {

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.config.ts
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.config.ts
@@ -8,6 +8,7 @@ export const BLANK_MACHINE_TEMPLATE: IMachineType = {
   qty: 1,
   availabilityZone: '',
   availableMachineTypes: null,
+  filter: '',
 };
 
 // TODO: an interface type need to be defined

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
@@ -143,6 +143,7 @@
                 <input #regionFilter
                        matInput
                        type="text"
+                       (keydown)="allowSpaces($event)"
                        placeholder="Filter regions..."
                        [(ngModel)]="regionsFilter"
                        [ngModelOptions]="{ standalone: true }">
@@ -169,6 +170,7 @@
                   <input #regionFilter
                          matInput
                          type="text"
+                         (keydown)="allowSpaces($event)"
                          placeholder="Filter regions..."
                          [(ngModel)]="regionsFilter"
                          [ngModelOptions]="{ standalone: true }">
@@ -222,6 +224,7 @@
                   <input #regionFilter
                          matInput
                          type="text"
+                         (keydown)="allowSpaces($event)"
                          placeholder="Filter regions..."
                          [(ngModel)]="regionsFilter"
                          [ngModelOptions]="{ standalone: true }">
@@ -266,6 +269,7 @@
                   <input #regionFilter
                          matInput
                          type="text"
+                         (keydown)="allowSpaces($event)"
                          placeholder="Filter regions..."
                          [(ngModel)]="regionsFilter"
                          [ngModelOptions]="{ standalone: true }">
@@ -348,6 +352,7 @@
                   <input #machineFilter
                          matInput
                          type="text"
+                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>
@@ -423,6 +428,7 @@
                   <input #machineFilter
                          matInput
                          type="text"
+                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>
@@ -496,6 +502,7 @@
                   <input #machineFilter
                          matInput
                          type="text"
+                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>
@@ -557,6 +564,7 @@
                   <input #machineFilter
                          matInput
                          type="text"
+                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
@@ -136,18 +136,19 @@
           <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
             <mat-select placeholder="Select a Region"
                         formControlName="region"
-                        (openedChange)="regionsFilter = ''"
+                        (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                         (selectionChange)="selectRegion($event.value)"
                         required>
-              <input class="select-filter"
-                     matInput
-                     type="text"
-                     placeholder="Filter regions..."
-                     [(ngModel)]="regionsFilter"
-                     [ngModelOptions]="{ standalone: true }"
-                     autofocus>
-              <mat-option *ngFor="let r of availableRegions?.regions | callback: regionsFilterCallback"
-                          [value]="r">{{ r.name }}</mat-option>
+              <div class="sticky-filter">
+                <input #regionFilter
+                       matInput
+                       type="text"
+                       placeholder="Filter regions..."
+                       [(ngModel)]="regionsFilter"
+                       [ngModelOptions]="{ standalone: true }">
+              </div>
+              <mat-option *ngFor="let r of availableRegionNames | callback: regionsFilter"
+                          [value]="r">{{ r }}</mat-option>
             </mat-select>
           </mat-form-field>
         </form>
@@ -161,18 +162,19 @@
             <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
               <mat-select placeholder="Select a Region"
                           formControlName="region"
-                          (openedChange)="regionsFilter = ''"
+                          (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                           (selectionChange)="selectRegion($event.value)"
                           required>
-                <input class="select-filter"
-                       matInput
-                       type="text"
-                       placeholder="Filter regions..."
-                       [(ngModel)]="regionsFilter"
-                       [ngModelOptions]="{ standalone: true }"
-                       autofocus>
-                <mat-option *ngFor="let r of availableRegions?.regions | callback: regionsFilterCallback"
-                            [value]="r">{{ r.name }}</mat-option>
+                <div class="sticky-filter">
+                  <input #regionFilter
+                         matInput
+                         type="text"
+                         placeholder="Filter regions..."
+                         [(ngModel)]="regionsFilter"
+                         [ngModelOptions]="{ standalone: true }">
+                </div>
+                <mat-option *ngFor="let r of availableRegionNames | callback: regionsFilter"
+                            [value]="r">{{ r }}</mat-option>
               </mat-select>
             </mat-form-field>
 
@@ -213,18 +215,19 @@
             <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
               <mat-select placeholder="Select a Region"
                           formControlName="region"
-                          (openedChange)="regionsFilter = ''"
+                          (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                           (selectionChange)="selectRegion($event.value)"
                           required>
-                <input class="select-filter"
-                       matInput
-                       type="text"
-                       placeholder="Filter regions..."
-                       [(ngModel)]="regionsFilter"
-                       [ngModelOptions]="{ standalone: true }"
-                       autofocus>
-                <mat-option *ngFor="let r of availableRegions?.regions | callback: regionsFilterCallback"
-                            [value]="r">{{ r.name }}</mat-option>
+                <div class="sticky-filter">
+                  <input #regionFilter
+                         matInput
+                         type="text"
+                         placeholder="Filter regions..."
+                         [(ngModel)]="regionsFilter"
+                         [ngModelOptions]="{ standalone: true }">
+                </div>
+                <mat-option *ngFor="let r of availableRegionNames | callback: regionsFilter"
+                            [value]="r">{{ r }}</mat-option>
               </mat-select>
             </mat-form-field>
           </div>
@@ -256,18 +259,19 @@
             <mat-form-field [ngClass]="{ 'regionsLoading': regionsLoading }">
               <mat-select placeholder="Select a Region"
                           formControlName="region"
-                          (openedChange)="regionsFilter = ''"
+                          (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                           (selectionChange)="selectRegion($event.value)"
                           required>
-                <input class="select-filter"
-                       matInput
-                       type="text"
-                       placeholder="Filter regions..."
-                       [(ngModel)]="regionsFilter"
-                       [ngModelOptions]="{ standalone: true }"
-                       autofocus>
-                <mat-option *ngFor="let r of availableRegions?.regions | callback: regionsFilterCallback"
-                            [value]="r">{{ r.name }}</mat-option>
+                <div class="sticky-filter">
+                  <input #regionFilter
+                         matInput
+                         type="text"
+                         placeholder="Filter regions..."
+                         [(ngModel)]="regionsFilter"
+                         [ngModelOptions]="{ standalone: true }">
+                </div>
+                <mat-option *ngFor="let r of availableRegionNames | callback: regionsFilter"
+                            [value]="r">{{ r }}</mat-option>
               </mat-select>
             </mat-form-field>
 
@@ -337,15 +341,16 @@
                           placeholder="Machine Type (size)"
                           id="m.machineType"
                           [(value)]="m.machineType"
-                          (openedChange)="machineTypesFilter = ''"
+                          (openedChange)="[m.filter = '', machineFilter.focus()]"
                           (selectionChange)="validateMachineConfig(m)">
-                <input class="select-filter"
-                       matInput
-                       type="text"
-                       placeholder="Filter machines..."
-                       [(ngModel)]="machineTypesFilter"
-                       autofocus>
-                <mat-option *ngFor="let type of availableMachineTypes | callback: machineTypesFilterCallback"
+                <div class="sticky-filter">
+                  <input #machineFilter
+                         matInput
+                         type="text"
+                         placeholder="Filter machines..."
+                         [(ngModel)]="m.filter">
+                </div>
+                <mat-option *ngFor="let type of availableMachineTypes | callback: m.filter"
                             [value]="type">{{ type }}</mat-option>
               </mat-select>
             </mat-form-field>
@@ -392,7 +397,7 @@
             <mat-form-field [ngClass]="{ 'azsLoading': azsLoading }">
               <mat-select placeholder="Select an Availability Zone"
                           [(value)]="m.availabilityZone"
-                          (openedChange)="machineTypesFilter = ''"
+                          (openedChange)="m.filter = ''"
                           (selectionChange)="selectAz($event.value, idx)"
                           required>
                 <mat-option *ngFor="let a of availabilityZones"
@@ -408,19 +413,17 @@
                           id="m.machineType"
                           [(value)]="m.machineType"
                           [disabled]="!m.availableMachineTypes"
-                          (openedChange)="machineTypesFilter = ''"
-                          (selectionChange)="validateMachineConfig(m)"
-                          required>
-                <input class="select-filter"
-                       matInput
-                       type="text"
-                       placeholder="Filter machines..."
-                       [(ngModel)]="machineTypesFilter"
-                       autofocus>
-                <mat-option *ngFor="let type of m.availableMachineTypes | callback: machineTypesFilterCallback"
-                            [value]="type">
-                  {{ type }}
-                </mat-option>
+                          (openedChange)="[m.filter = '', machineFilter.focus()]"
+                          (selectionChange)="validateMachineConfig(m)">
+                <div class="sticky-filter">
+                  <input #machineFilter
+                         matInput
+                         type="text"
+                         placeholder="Filter machines..."
+                         [(ngModel)]="m.filter">
+                </div>
+                <mat-option *ngFor="let type of m.availableMachineTypes | callback: m.filter"
+                            [value]="type">{{ type }}</mat-option>
               </mat-select>
             </mat-form-field>
 
@@ -468,7 +471,7 @@
             <mat-form-field [ngClass]="{ 'azsLoading': azsLoading }">
               <mat-select placeholder="Select an Availability Zone"
                           [(value)]="m.availabilityZone"
-                          (openedChange)="machineTypesFilter = ''"
+                          (openedChange)="m.filter = ''"
                           (selectionChange)="selectAz($event.value, idx)"
                           required>
                 <mat-option *ngFor="let a of availabilityZones"
@@ -482,18 +485,17 @@
                           placeholder="Machine Type (size)"
                           [(value)]="m.machineType"
                           [disabled]="!m.availableMachineTypes"
-                          (openedChange)="machineTypesFilter = ''"
+                          (openedChange)="[m.filter = '', machineFilter.focus()]"
                           (selectionChange)="validateMachineConfig(m)">
-                <input class="select-filter"
-                       matInput
-                       type="text"
-                       placeholder="Filter machines..."
-                       [(ngModel)]="machineTypesFilter"
-                       autofocus>
-                <mat-option *ngFor="let type of m.availableMachineTypes | callback: machineTypesFilterCallback"
-                            [value]="type">
-                  {{ type }}
-                </mat-option>
+                <div class="sticky-filter">
+                  <input #machineFilter
+                         matInput
+                         type="text"
+                         placeholder="Filter machines..."
+                         [(ngModel)]="m.filter">
+                </div>
+                <mat-option *ngFor="let type of m.availableMachineTypes | callback: m.filter"
+                            [value]="type">{{ type }}</mat-option>
               </mat-select>
             </mat-form-field>
 
@@ -541,15 +543,16 @@
                           placeholder="Machine Type (size)"
                           id="m.machineType"
                           [(value)]="m.machineType"
-                          (openedChange)="machineTypesFilter = ''"
+                          (openedChange)="[m.filter = '', machineFilter.focus()]"
                           (selectionChange)="validateMachineConfig(m)">
-                <input class="select-filter"
-                       matInput
-                       type="text"
-                       placeholder="Filter machines..."
-                       [(ngModel)]="machineTypesFilter"
-                       autofocus>
-                <mat-option *ngFor="let type of availableMachineTypes | callback: machineTypesFilterCallback"
+                <div class="sticky-filter">
+                  <input #machineFilter
+                         matInput
+                         type="text"
+                         placeholder="Filter machines..."
+                         [(ngModel)]="m.filter">
+                </div>
+                <mat-option *ngFor="let type of availableMachineTypes | callback: m.filter"
                             [value]="type">{{ type }}</mat-option>
               </mat-select>
             </mat-form-field>
@@ -629,25 +632,25 @@
             <h3>PROVIDER CONFIGURATION</h3>
             <!-- digital ocean -->
             <div *ngIf="selectedCloudAccount?.provider == 'digitalocean'">
-              <p><span class="label">REGION:</span> {{ providerConfig.value.region.name }}</p>
+              <p><span class="label">REGION:</span> {{ providerConfig.value.region }}</p>
             </div>
 
             <!-- aws -->
             <div *ngIf="selectedCloudAccount?.provider == 'aws'">
-              <p><span class="label">REGION: </span> {{ providerConfig.value.region.name }}</p>
+              <p><span class="label">REGION: </span> {{ providerConfig.value.region }}</p>
               <p><span class="label">VPC CIDR: </span> {{ providerConfig.value.vpcCidr }}</p>
               <p><span class="label">PUBLIC KEY: </span><span class="action" (click)="showPublicKey()">review</span></p>
             </div>
 
             <!-- gce -->
             <div *ngIf="selectedCloudAccount?.provider == 'gce'">
-              <p><span class="label">REGION:</span> {{ providerConfig.value.region.name }}</p>
+              <p><span class="label">REGION:</span> {{ providerConfig.value.region }}</p>
               <p><span class="label">PUBLIC KEY: </span><span class="action" (click)="showPublicKey()">review</span></p>
             </div>
 
             <!-- azure -->
             <div *ngIf="selectedCloudAccount?.provider == 'azure'">
-              <p><span class="label">REGION:</span> {{ providerConfig.value.region.name }}</p>
+              <p><span class="label">REGION:</span> {{ providerConfig.value.region }}</p>
               <p><span class="label">VNet CIDR:</span> {{ providerConfig.value.azureVNetCIDR }}</p>
               <p><span class="label">PUBLIC KEY: </span><span class="action" (click)="showPublicKey()">review</span></p>
             </div>

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
@@ -139,7 +139,7 @@
                         (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                         (selectionChange)="selectRegion($event.value)"
                         required>
-              <div class="sticky-filter">
+              <div class="sticky-filter-wrapper">
                 <input #regionFilter
                        matInput
                        type="text"
@@ -166,7 +166,7 @@
                           (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                           (selectionChange)="selectRegion($event.value)"
                           required>
-                <div class="sticky-filter">
+                <div class="sticky-filter-wrapper">
                   <input #regionFilter
                          matInput
                          type="text"
@@ -220,7 +220,7 @@
                           (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                           (selectionChange)="selectRegion($event.value)"
                           required>
-                <div class="sticky-filter">
+                <div class="sticky-filter-wrapper">
                   <input #regionFilter
                          matInput
                          type="text"
@@ -265,7 +265,7 @@
                           (openedChange)="[regionsFilter = '', regionFilter.focus()]"
                           (selectionChange)="selectRegion($event.value)"
                           required>
-                <div class="sticky-filter">
+                <div class="sticky-filter-wrapper">
                   <input #regionFilter
                          matInput
                          type="text"
@@ -348,11 +348,10 @@
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
                           (selectionChange)="validateMachineConfig(m)"
                           required>
-                <div class="sticky-filter">
+                <div class="sticky-filter-wrapper">
                   <input #machineFilter
                          matInput
                          type="text"
-                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>
@@ -424,11 +423,10 @@
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
                           (selectionChange)="validateMachineConfig(m)"
                           required>
-                <div class="sticky-filter">
+                <div class="sticky-filter-wrapper">
                   <input #machineFilter
                          matInput
                          type="text"
-                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>
@@ -498,11 +496,10 @@
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
                           (selectionChange)="validateMachineConfig(m)"
                           required>
-                <div class="sticky-filter">
+                <div class="sticky-filter-wrapper">
                   <input #machineFilter
                          matInput
                          type="text"
-                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>
@@ -560,11 +557,10 @@
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
                           (selectionChange)="validateMachineConfig(m)"
                           required>
-                <div class="sticky-filter">
+                <div class="sticky-filter-wrapper">
                   <input #machineFilter
                          matInput
                          type="text"
-                         (keydown)="allowSpaces($event)"
                          placeholder="Filter machines..."
                          [(ngModel)]="m.filter">
                 </div>

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.html
@@ -342,7 +342,8 @@
                           id="m.machineType"
                           [(value)]="m.machineType"
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
-                          (selectionChange)="validateMachineConfig(m)">
+                          (selectionChange)="validateMachineConfig(m)"
+                          required>
                 <div class="sticky-filter">
                   <input #machineFilter
                          matInput
@@ -358,7 +359,8 @@
             <mat-form-field>
               <mat-select placeholder="Role"
                           [(value)]="m.role"
-                          (selectionChange)="validateMachineConfig(m)">
+                          (selectionChange)="validateMachineConfig(m)"
+                          required>
                 <mat-option value="Master">Master</mat-option>
                 <mat-option value="Node">Node</mat-option>
               </mat-select>
@@ -370,7 +372,8 @@
                      min="1"
                      placeholder="Q-ty"
                      [(ngModel)]="m.qty"
-                     (ngModelChange)="validateMachineConfig(m)">
+                     (ngModelChange)="validateMachineConfig(m)"
+                     required>
             </mat-form-field>
 
             <div class="delete"
@@ -414,7 +417,8 @@
                           [(value)]="m.machineType"
                           [disabled]="!m.availableMachineTypes"
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
-                          (selectionChange)="validateMachineConfig(m)">
+                          (selectionChange)="validateMachineConfig(m)"
+                          required>
                 <div class="sticky-filter">
                   <input #machineFilter
                          matInput
@@ -486,7 +490,8 @@
                           [(value)]="m.machineType"
                           [disabled]="!m.availableMachineTypes"
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
-                          (selectionChange)="validateMachineConfig(m)">
+                          (selectionChange)="validateMachineConfig(m)"
+                          required>
                 <div class="sticky-filter">
                   <input #machineFilter
                          matInput
@@ -502,7 +507,8 @@
             <mat-form-field class="role">
               <mat-select placeholder="Role"
                           [(value)]="m.role"
-                          (selectionChange)="validateMachineConfig(m)">
+                          (selectionChange)="validateMachineConfig(m)"
+                          required>
                 <mat-option value="Master">Master</mat-option>
                 <mat-option value="Node">Node</mat-option>
               </mat-select>
@@ -514,7 +520,8 @@
                      min="1"
                      placeholder="Q-ty"
                      [(ngModel)]="m.qty"
-                     (ngModelChange)="validateMachineConfig(m)">
+                     (ngModelChange)="validateMachineConfig(m)"
+                     required>
             </mat-form-field>
 
             <div class="delete"
@@ -544,7 +551,8 @@
                           id="m.machineType"
                           [(value)]="m.machineType"
                           (openedChange)="[m.filter = '', machineFilter.focus()]"
-                          (selectionChange)="validateMachineConfig(m)">
+                          (selectionChange)="validateMachineConfig(m)"
+                          required>
                 <div class="sticky-filter">
                   <input #machineFilter
                          matInput
@@ -560,7 +568,8 @@
             <mat-form-field class="role">
               <mat-select placeholder="Role"
                           [(value)]="m.role"
-                          (selectionChange)="validateMachineConfig(m)">
+                          (selectionChange)="validateMachineConfig(m)"
+                          required>
                 <mat-option value="Master">Master</mat-option>
                 <mat-option value="Node">Node</mat-option>
               </mat-select>
@@ -572,7 +581,8 @@
                      min="1"
                      placeholder="Q-ty"
                      [(ngModel)]="m.qty"
-                     (ngModelChange)="validateMachineConfig(m)">
+                     (ngModelChange)="validateMachineConfig(m)"
+                     required>
             </mat-form-field>
 
             <div class="delete"

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.interface.ts
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.interface.ts
@@ -5,4 +5,5 @@ export interface IMachineType {
   availabilityZone: string;
   availableMachineTypes: string[];
   recommendedNodesCount?: number;
+  filter: string;
 }

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
@@ -312,18 +312,20 @@
     }
   }
 }
-.mat-form-field:not(.mat-focused)  {
+.mat-form-field:not(.mat-focused) {
   .mat-form-field-underline {
     opacity: .25;
     background-color: white!important;
   }
 }
 
-.mat-select-content {
-  .select-filter {
-    position: relative;
-    padding: 10px !important;
-  }
+.sticky-filter {
+  position: sticky;
+  padding: 10px !important;
+  z-index: 100;
+  top: 0;
+  background-color: #424242;
+  border-bottom: 1px solid rgba(255,255,255,0.25);
 }
 
 .mat-hint {

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.scss
@@ -319,7 +319,7 @@
   }
 }
 
-.sticky-filter {
+.sticky-filter-wrapper {
   position: sticky;
   padding: 10px !important;
   z-index: 100;

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
@@ -558,4 +558,10 @@ export class NewClusterComponent implements OnInit, OnDestroy {
     return dialogRef;
   }
 
+  allowSpaces(keyEvent){
+    if(keyEvent.key==" "){
+      keyEvent.stopPropagation();
+    }
+  }
+
 }

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
@@ -53,7 +53,6 @@ export class NewClusterComponent implements OnInit, OnDestroy {
   availableCloudAccounts$: Observable<any[]>;
   selectedCloudAccount: any;
   availableRegions: any;
-  availableRegionsSansProvider: any;
   availableRegionNames: Array<string>;
   availableMachineTypes: Array<any>;
   regionsLoading = false;
@@ -190,7 +189,7 @@ export class NewClusterComponent implements OnInit, OnDestroy {
       newClusterData.profile.masterProfiles = this.nodesService.compileProfiles(this.selectedCloudAccount.provider, this.machines, 'Master');
       newClusterData.profile.nodesProfiles = this.nodesService.compileProfiles(this.selectedCloudAccount.provider, this.machines, 'Node');
 
-      let region = this.availableRegionsSansProvider.filter(reg => {
+      let region = this.availableRegions.filter(reg => {
         return reg.name === this.providerConfig.value.region
       })[0];
       newClusterData.profile.region = region.id;
@@ -315,7 +314,7 @@ export class NewClusterComponent implements OnInit, OnDestroy {
 
   selectRegion(regionName) {
 
-    let region = this.availableRegionsSansProvider.filter(reg => {
+    let region = this.availableRegions.filter(reg => {
       return reg.name === regionName
     })[0];
 
@@ -440,9 +439,8 @@ export class NewClusterComponent implements OnInit, OnDestroy {
     this.subscriptions.add(this.supergiant.CloudAccounts.getRegions(cloudAccount.name).subscribe(
       regionList => {
         this.availableRegions = regionList;
-        this.availableRegions.regions.sort(this.sortRegionsByName);
-        this.availableRegionNames = this.availableRegions.regions.map(n => n.name);
-        this.availableRegionsSansProvider = this.availableRegions.regions;
+        this.availableRegions = this.availableRegions.regions.sort(this.sortRegionsByName);
+        this.availableRegionNames = this.availableRegions.map(n => n.name);
         this.regionsLoading = false;
       },
       err => {

--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
@@ -438,8 +438,7 @@ export class NewClusterComponent implements OnInit, OnDestroy {
     this.regionsLoading = true;
     this.subscriptions.add(this.supergiant.CloudAccounts.getRegions(cloudAccount.name).subscribe(
       regionList => {
-        this.availableRegions = regionList;
-        this.availableRegions = this.availableRegions.regions.sort(this.sortRegionsByName);
+        this.availableRegions = regionList.regions.sort(this.sortRegionsByName);
         this.availableRegionNames = this.availableRegions.map(n => n.name);
         this.regionsLoading = false;
       },


### PR DESCRIPTION
* applies to Region and Machine Type drop-downs for all providers on cluster provisioning wizard
* locks filter at top of drop-down when user scrolls through drop-down
* sets focus into filter field as soon as user clicks on drop-down
* changes custom callback pipe into pure function
* requires machine config fields for all providers
* resolves cards S20-1010 and S20-948

<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [ ] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [x] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

Example: Introduces a new cloud provider for provisioning and managing kubes on GCE, due to popular demand.

<!-- Specify the GitHub issue this PR fixes, if any. -->

Example: Fixes #78, #89, #123

### Additional Details?

<!-- Add important details of the PR below, or put "NONE." -->
<!-- Includes actions users must take to use the changes. -->

Example: In order to take advantage of this new feature, users will need to restart SG Control with the `gce` provider option added to the `providers` flag: `--providers=gce,aws,etc.` Otherwise, functionality is not changed.

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [x] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
