### PR TITLE
Hide AWS gov regions from UI for cluster provisioning

### DIFF
--- a/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
+++ b/cmd/ui/assets/src/app/clusters/new-cluster/new-cluster.component.ts
@@ -440,6 +440,11 @@ export class NewClusterComponent implements OnInit, OnDestroy {
       regionList => {
         this.availableRegions = regionList.regions.sort(this.sortRegionsByName);
         this.availableRegionNames = this.availableRegions.map(n => n.name);
+        if(this.selectedCloudAccount.provider == 'aws'){
+          // '-gov-' VMs return 500 when AZs try to load
+          const filterName = "-gov-";
+          this.availableRegionNames = this.availableRegionNames.filter(vmName => !vmName.includes(filterName));
+        }
         this.regionsLoading = false;
       },
       err => {


### PR DESCRIPTION
* hides the AWS gov regions from Regions drop-down in new cluster provisioning wizard
* this prevents a 500 error from being returned and the AZs failing to load when user who doesn't have rights to use gov region chooses one
* because AZs failing to load is the problem this PR is intended to solve, I'm not hiding gov regions from Cluster Import's Regions drop-down, since AZs aren't included as an option in that wizard
* solves card S20-1051

<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [ ] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [x] Other (please **explain** below)
UI change only

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

Example: Introduces a new cloud provider for provisioning and managing kubes on GCE, due to popular demand.

<!-- Specify the GitHub issue this PR fixes, if any. -->

Example: Fixes #78, #89, #123

### Additional Details?

<!-- Add important details of the PR below, or put "NONE." -->
<!-- Includes actions users must take to use the changes. -->

Example: In order to take advantage of this new feature, users will need to restart SG Control with the `gce` provider option added to the `providers` flag: `--providers=gce,aws,etc.` Otherwise, functionality is not changed.

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [x] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
