### PR TITLE
Add hint to Private SSH Key on Cluster Import

### DIFF
--- a/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.html
@@ -90,6 +90,7 @@
           </mat-form-field>
           <mat-form-field>
             <textarea matInput rows="4" formControlName="privateKey" placeholder="Private SSH Key" required></textarea>
+            <mat-hint align="end">Add the Private SSH Key of the Kubernetes cluster you wish to import. If you are importing a Supergiant-created cluster, you can download the needed Private Key from the cluster's detail page.</mat-hint>
           </mat-form-field>
         </div>
       </form>

--- a/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.html
+++ b/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.html
@@ -90,7 +90,7 @@
           </mat-form-field>
           <mat-form-field>
             <textarea matInput rows="4" formControlName="privateKey" placeholder="Private SSH Key" required></textarea>
-            <mat-hint align="end">Add the Private SSH Key of the Kubernetes cluster you wish to import. If you are importing a Supergiant-created cluster, you can download the needed Private Key from the cluster's detail page.</mat-hint>
+            <mat-hint align="end">Provide the ubuntu user’s private key that allows ssh access to your Kubernetes cluster. If you are importing a Supergiant-created cluster, you can download the needed private key from the cluster’s detail page.</mat-hint>
           </mat-form-field>
         </div>
       </form>

--- a/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.scss
+++ b/cmd/ui/assets/src/app/clusters/import-cluster/import-cluster.component.scss
@@ -107,3 +107,11 @@
 .mat-spinner {
   display: inline-block;
 }
+
+.mat-hint {
+  align-self: flex-end;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 12px;
+  font-style: italic;
+  margin-left: auto;
+}


### PR DESCRIPTION
* adds hint describing which Private SSH Key user should input
* resolves card S20-1047

<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [ ] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [x] Other (please **explain** below)
UI change only

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

Example: Introduces a new cloud provider for provisioning and managing kubes on GCE, due to popular demand.

<!-- Specify the GitHub issue this PR fixes, if any. -->

Example: Fixes #78, #89, #123

### Additional Details?

<!-- Add important details of the PR below, or put "NONE." -->
<!-- Includes actions users must take to use the changes. -->

Example: In order to take advantage of this new feature, users will need to restart SG Control with the `gce` provider option added to the `providers` flag: `--providers=gce,aws,etc.` Otherwise, functionality is not changed.

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [x] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
