### PR TITLE
Update kube-apiserver/kubelet certificate CN fields

### DIFF
--- a/pkg/workflows/steps/certificates/certificates.go
+++ b/pkg/workflows/steps/certificates/certificates.go
@@ -43,10 +43,10 @@ func (s *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	config.CertificatesConfig.PrivateIP = config.Node.PrivateIp
 	config.CertificatesConfig.PublicIP = config.Node.PublicIp
 	config.CertificatesConfig.IsMaster = config.IsMaster
+	config.CertificatesConfig.Provider = string(config.Provider)
 
 	if !config.IsMaster {
 		config.CertificatesConfig.MasterHost = config.InternalDNSName
-		config.CertificatesConfig.NodeName = config.Node.Name
 	}
 
 	if len(config.CertificatesConfig.ServicesCIDR) > 0 {

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -21,10 +21,10 @@ type CertificatesConfig struct {
 	ServicesCIDR string `json:"servicesCIDR"`
 	PublicIP     string `json:"publicIp"`
 	PrivateIP    string `json:"privateIp"`
+	Provider     string `json:"provider"`
 
 	MasterHost string `json:"masterHost"`
 	MasterPort string `json:"masterPort"`
-	NodeName   string `json:"nodeName"`
 
 	IsMaster bool `json:"isMaster"`
 	// TODO: this shouldn't be a part of SANs


### PR DESCRIPTION
<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [x] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [ ] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

Kubernetes uses certificate CN names for authorization. Update kube-apiserver/kubelet certificate CN name to follow docs.
kube-apiserver: https://kubernetes.io/docs/setup/certificates/#all-certificates
kubelet: https://kubernetes.io/docs/setup/certificates/#configure-certificates-for-user-accounts

<!-- Specify the GitHub issue this PR fixes, if any. -->

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [x] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
