### PR TITLE
Fix nil pointer dereference in sync machines

### DIFF
--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -114,12 +114,18 @@ func syncMachines(ctx context.Context, k *model.Kube, account *model.CloudAccoun
 	for _, res := range describeInstanceOutput.Reservations {
 		for _, instance := range res.Instances {
 			node := &model.Machine{
-				PrivateIp: *instance.PrivateIpAddress,
-				PublicIp:  *instance.PublicIpAddress,
 				Size:      *instance.InstanceType,
 				State:     model.MachineStateActive,
 				Role:      model.RoleNode,
 				Region:    k.Region,
+			}
+
+			if instance.PublicIpAddress != nil {
+				node.PublicIp = *instance.PublicIpAddress
+			}
+
+			if instance.PrivateIpAddress != nil {
+				node.PrivateIp = *instance.PrivateIpAddress
 			}
 
 			for _, tag := range instance.Tags {
@@ -131,7 +137,7 @@ func syncMachines(ctx context.Context, k *model.Kube, account *model.CloudAccoun
 			isFound := false
 
 			for _, machine := range k.Nodes {
-				if machine.PrivateIp == *instance.PrivateIpAddress {
+				if instance.PrivateIpAddress != nil && machine.PrivateIp == *instance.PrivateIpAddress {
 					isFound = true
 				}
 			}

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -142,8 +142,14 @@ func syncMachines(ctx context.Context, k *model.Kube, account *model.CloudAccoun
 				}
 			}
 
+			var state int64
+
+			if instance.State != nil && instance.State.Code != nil {
+				state = *instance.State.Code
+			}
+
 			// If node is new in workers and it is not a master
-			if !isFound && k.Masters[node.Name] == nil {
+			if !isFound && k.Masters[node.Name] == nil && state == 16 {
 				logrus.Debugf("Add new node %v", node)
 				k.Nodes[node.Name] = node
 			}


### PR DESCRIPTION
Fix sync machines nil pointer dereference
Filter machines in terminated state