### PR TITLE
Add TLS support for the control server

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -17,7 +17,10 @@ import (
 var (
 	version       = "unstable"
 	addr          = flag.String("address", "0.0.0.0", "network interface to attach server to")
-	port          = flag.Int("port", 8080, "tcp port to listen for incoming requests")
+	port          = flag.Int("port", 0, "secure tcp port to listen to for incoming HTTPS requests. Provide server certificates with -cert-file and -key-file flags")
+	insecurePort  = flag.Int("insecure-port", 8080, "tcp port to listen for incoming HTTP requests. if -port is set this flag will be ignored")
+	certFile      = flag.String("cert-file", "", "file containing server x509 certificate")
+	keyFile       = flag.String("key-file", "", "file containing x509 private key matching --cert-file")
 	storageMode   = flag.String("storage-mode", "file", "storage type either file(default), memory or etcd")
 	storageURI    = flag.String("storage-uri", "supergiant.db", "uri of storage depends on selected storage type, for memory storage type this is empty")
 	templatesDir  = flag.String("templates", "", "supergiant will load script templates from the specified directory on start")
@@ -39,6 +42,9 @@ func main() {
 	cfg := &controlplane.Config{
 		Addr:          *addr,
 		Port:          *port,
+		InsecurePort:  *insecurePort,
+		CertFile:      *certFile,
+		KeyFile:       *keyFile,
 		StorageMode:   *storageMode,
 		StorageURI:    *storageURI,
 		TemplatesDir:  *templatesDir,
@@ -68,7 +74,6 @@ func main() {
 		server.Shutdown()
 	}()
 
-	logrus.Infof("supergiant is starting on port %d", *port)
 	server.Start()
 }
 

--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -60,7 +61,15 @@ type Server struct {
 }
 
 func (srv *Server) Start() {
-	err := srv.server.ListenAndServe()
+	logrus.Infof("configuratino: %+v", srv.cfg)
+	logrus.Infof("supergiant is listening on %s", srv.server.Addr)
+
+	var err error
+	if srv.server.TLSConfig != nil {
+		err = srv.server.ListenAndServeTLS(srv.cfg.CertFile, srv.cfg.KeyFile)
+	} else {
+		err = srv.server.ListenAndServe()
+	}
 	if err != nil {
 		logrus.Error(err)
 	}
@@ -79,6 +88,9 @@ func (srv *Server) Shutdown() {
 // Config is the server configuration
 type Config struct {
 	Port          int
+	InsecurePort  int
+	CertFile      string
+	KeyFile       string
 	Addr          string
 	StorageMode   string
 	StorageURI    string
@@ -106,12 +118,10 @@ func New(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 
-	s := NewServer(r, cfg)
-
-	return s, nil
+	return NewServer(r, cfg)
 }
 
-func NewServer(router *mux.Router, cfg *Config) *Server {
+func NewServer(router *mux.Router, cfg *Config) (*Server, error) {
 	headersOk := handlers.AllowedHeaders([]string{
 		"Access-Control-Request-Headers",
 		"Authorization",
@@ -125,27 +135,34 @@ func NewServer(router *mux.Router, cfg *Config) *Server {
 		http.MethodDelete,
 	})
 
-	// TODO add TLS support
-	s := &Server{
+	port := cfg.InsecurePort
+	var tlsCfg *tls.Config
+	if cfg.Port != 0 {
+		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "load server certificates")
+		}
+
+		port = cfg.Port
+		tlsCfg = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		}
+	}
+
+	return &Server{
 		cfg: cfg,
 		server: http.Server{
 			Handler:      handlers.CORS(headersOk, methodsOk)(handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(router)),
-			Addr:         fmt.Sprintf("%s:%d", cfg.Addr, cfg.Port),
+			Addr:         fmt.Sprintf("%s:%d", cfg.Addr, port),
 			ReadTimeout:  cfg.ReadTimeout,
 			WriteTimeout: cfg.WriteTimeout,
 			IdleTimeout:  cfg.IdleTimeout,
+			TLSConfig:    tlsCfg,
 		},
-	}
-	http.DefaultClient.Timeout = cfg.IdleTimeout
-
-	return s
+	}, nil
 }
 
 func validate(cfg *Config) error {
-	if cfg.Port <= 0 {
-		return errors.New("port can't be negative")
-	}
-
 	if cfg.SpawnInterval == 0 {
 		return errors.New("spawn interval must not be 0")
 	}

--- a/pkg/controlplane/server_test.go
+++ b/pkg/controlplane/server_test.go
@@ -53,7 +53,11 @@ func TestNewServer(t *testing.T) {
 		router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		})
 
-		server := NewServer(router, testCase.cfg)
+		server, err := NewServer(router, testCase.cfg)
+		if err != nil {
+			t.Errorf("create sg server: %s", err)
+		}
+
 		rec := httptest.NewRecorder()
 		req, err := http.NewRequest(testCase.method, "/", nil)
 


### PR DESCRIPTION
<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [ ] Fix (a **bug** or other **issue** was fixed)
- [x] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [ ] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

This change introduces TLS support for control. To serve HTTPS requests run the binary with the app flags:
```
control -port=8443 -cert-file=server.crt -key-file=server.key
```
To serve HTTP requests use `-insecure-port`.
Control listens on 8080 insecure port by default.

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
