### PR TITLE
Fix adding node to a cluster

### DIFF
--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -76,6 +76,7 @@ type Auth struct {
 	Password       string `json:"token"`
 	CAKey          string `json:"caKey"`
 	CACert         string `json:"caCert"`
+	CACertHash     string `json:"caCertHash"`
 	AdminCert      string `json:"adminCert"`
 	AdminKey       string `json:"adminKey"`
 	CertificateKey string `json:"certificateKey"`

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -18,6 +18,7 @@ func UpdateKubeWithCloudSpecificData(k *model.Kube, config *steps.Config) {
 	k.InternalDNSName = config.InternalDNSName
 	k.BootstrapToken = config.BootstrapToken
 	k.K8SVersion = config.K8SVersion
+	k.Auth.CACertHash = config.CertificatesConfig.CACertHash
 
 	// Save cloudSpecificData in kube
 	switch config.Provider {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -147,6 +147,7 @@ func LoadCloudSpecificDataFromKube(k *model.Kube, config *steps.Config) error {
 	}
 
 	config.KubeadmConfig.CertificateKey = k.Auth.CertificateKey
+	config.CertificatesConfig.CACertHash = k.Auth.CACertHash
 	config.K8SVersion = k.K8SVersion
 
 	switch config.Provider {

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -409,11 +409,11 @@ func NewConfig(clusterName, cloudAccountName string, profile profile.Profile) (*
 		},
 		KubeadmConfig: KubeadmConfig{
 			// TODO(stgleb): get it from available versions once we have them
-			KubeadmVersion:     "1.15.0",
-			K8SVersion:  profile.K8SVersion,
-			IsBootstrap: true,
-			CIDR:        profile.CIDR,
-			ServiceCIDR: profile.K8SServicesCIDR,
+			KubeadmVersion: "1.15.0",
+			K8SVersion:     profile.K8SVersion,
+			IsBootstrap:    true,
+			CIDR:           profile.CIDR,
+			ServiceCIDR:    profile.K8SServicesCIDR,
 		},
 
 		Masters: Map{
@@ -519,11 +519,12 @@ func NewConfigFromKube(profile *profile.Profile, k *model.Kube) (*Config, error)
 			RBACEnabled: profile.RBACEnabled,
 		},
 		KubeadmConfig: KubeadmConfig{
-			K8SVersion:  profile.K8SVersion,
-			IsBootstrap: true,
-			Token:       k.BootstrapToken,
-			CIDR:        profile.CIDR,
-			ServiceCIDR: profile.K8SServicesCIDR,
+			KubeadmVersion: "1.15.0",
+			K8SVersion:     profile.K8SVersion,
+			IsBootstrap:    true,
+			Token:          k.BootstrapToken,
+			CIDR:           profile.CIDR,
+			ServiceCIDR:    profile.K8SServicesCIDR,
 		},
 		Masters: Map{
 			internal: make(map[string]*model.Machine, len(profile.MasterProfiles)),


### PR DESCRIPTION
Store ca-cert-hash into cluster Auth structure for adding nodes
and add kubeadm version to config constructor when create
from existing cluster