### PR TITLE
Make kubernetes api port configurable

### DIFF
--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/supergiant/control/pkg/workflows/steps/apply"
-	"github.com/supergiant/control/pkg/workflows/steps/evacuate"
-	"github.com/supergiant/control/pkg/workflows/steps/uncordon"
-	"github.com/supergiant/control/pkg/workflows/steps/upgrade"
 	"net/http"
 	_ "net/http/pprof"
 	"net/url"
@@ -19,8 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rakyll/statik/fs"
 	"github.com/sirupsen/logrus"
-	"k8s.io/helm/pkg/repo"
-
 	"github.com/supergiant/control/pkg/account"
 	"github.com/supergiant/control/pkg/api"
 	"github.com/supergiant/control/pkg/jwt"
@@ -36,6 +30,7 @@ import (
 	"github.com/supergiant/control/pkg/user"
 	"github.com/supergiant/control/pkg/workflows"
 	"github.com/supergiant/control/pkg/workflows/steps/amazon"
+	"github.com/supergiant/control/pkg/workflows/steps/apply"
 	"github.com/supergiant/control/pkg/workflows/steps/authorizedkeys"
 	"github.com/supergiant/control/pkg/workflows/steps/azure"
 	"github.com/supergiant/control/pkg/workflows/steps/bootstraptoken"
@@ -47,6 +42,7 @@ import (
 	"github.com/supergiant/control/pkg/workflows/steps/docker"
 	"github.com/supergiant/control/pkg/workflows/steps/downloadk8sbinary"
 	"github.com/supergiant/control/pkg/workflows/steps/drain"
+	"github.com/supergiant/control/pkg/workflows/steps/evacuate"
 	"github.com/supergiant/control/pkg/workflows/steps/gce"
 	"github.com/supergiant/control/pkg/workflows/steps/kubeadm"
 	"github.com/supergiant/control/pkg/workflows/steps/kubelet"
@@ -56,7 +52,10 @@ import (
 	"github.com/supergiant/control/pkg/workflows/steps/ssh"
 	"github.com/supergiant/control/pkg/workflows/steps/storageclass"
 	"github.com/supergiant/control/pkg/workflows/steps/tiller"
+	"github.com/supergiant/control/pkg/workflows/steps/uncordon"
+	"github.com/supergiant/control/pkg/workflows/steps/upgrade"
 	_ "github.com/supergiant/control/statik"
+	"k8s.io/helm/pkg/repo"
 )
 
 type Server struct {
@@ -264,8 +263,9 @@ func configureApplication(cfg *Config) (*mux.Router, error) {
 	amazon.InitImportRouteTablesStep(amazon.GetEC2)
 	amazon.InitCreateTagsStep(amazon.GetEC2)
 	apply.Init()
-	workflows.Init()
 	azure.Init()
+
+	workflows.Init()
 
 	taskHandler := workflows.NewTaskHandler(repository, sshRunner.NewRunner, accountService, cfg.LogDir)
 	taskHandler.Register(protectedAPI)

--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -4,28 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pborman/uuid"
-	"github.com/supergiant/control/pkg/kubeconfig"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
 
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/asaskevich/govalidator.v8"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"k8s.io/client-go/rest"
-	clientcmddapi "k8s.io/client-go/tools/clientcmd/api"
-
 	"github.com/supergiant/control/pkg/clouds"
+	"github.com/supergiant/control/pkg/kubeconfig"
 	"github.com/supergiant/control/pkg/message"
 	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/profile"
@@ -36,6 +26,13 @@ import (
 	"github.com/supergiant/control/pkg/workflows"
 	"github.com/supergiant/control/pkg/workflows/statuses"
 	"github.com/supergiant/control/pkg/workflows/steps"
+	"gopkg.in/asaskevich/govalidator.v8"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmddapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (
@@ -995,7 +992,7 @@ func (h *Handler) getClusterMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for metricType, relUrl := range metricsRelUrls {
-		url := fmt.Sprintf("https://%s/%s/%s", k.ExternalDNSName, baseUrl, relUrl)
+		url := fmt.Sprintf("/%s/%s", baseUrl, relUrl)
 		metricResponse, err := h.getMetrics(url, k)
 
 		if err != nil {
@@ -1040,7 +1037,7 @@ func (h *Handler) getNodesMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for metricType, relUrl := range metricsRelUrls {
-		url := fmt.Sprintf("https://%s/%s/%s", k.ExternalDNSName, baseUrl, relUrl)
+		url := fmt.Sprintf("/%s/%s", baseUrl, relUrl)
 		metricResponse, err := h.getMetrics(url, k)
 
 		if err != nil {

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/supergiant/control/pkg/model"
+	"github.com/supergiant/control/pkg/sgerrors"
+	"github.com/supergiant/control/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/discovery"
@@ -13,10 +16,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmddapi "k8s.io/client-go/tools/clientcmd/api"
-
-	"github.com/supergiant/control/pkg/model"
-	"github.com/supergiant/control/pkg/sgerrors"
-	"github.com/supergiant/control/pkg/util"
 )
 
 func NewConfigFor(k *model.Kube) (*rest.Config, error) {
@@ -77,14 +76,14 @@ func AdminKubeConfig(k *model.Kube) (clientcmddapi.Config, error) {
 	var apiAddr string
 	if k.ExternalDNSName != "" {
 		if strings.HasPrefix(k.ExternalDNSName, "https") {
-			apiAddr = k.ExternalDNSName
+			apiAddr = fmt.Sprintf("%s:%d", k.ExternalDNSName, k.APIServerPort)
 		} else {
-			apiAddr = fmt.Sprintf("https://%s", k.ExternalDNSName)
+			apiAddr = fmt.Sprintf("https://%s:%d", k.ExternalDNSName, k.APIServerPort)
 		}
 	} else {
 		// Use public IP in case if DNS name is absent
 		m := util.GetRandomNode(k.Masters)
-		apiAddr = fmt.Sprintf("https://%s", m.PublicIp)
+		apiAddr = fmt.Sprintf("https://%s:%d", m.PublicIp, k.APIServerPort)
 	}
 
 	// TODO: add validation

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -28,8 +28,10 @@ type Kube struct {
 	Zone         string      `json:"zone" valid:"-"`
 	ServicesCIDR string      `json:"servicesCIDR"`
 	DNSIP        string      `json:"dnsIp"`
-	APIPort      string      `json:"apiPort"`
-	Auth         Auth        `json:"auth"`
+	// DEPRECATED: use APIServerPort instead.
+	APIPort       string `json:"apiPort"`
+	APIServerPort int64  `json:"apibindPort"`
+	Auth          Auth   `json:"auth"`
 
 	User     string `json:"user" valid:"-"`
 	Password string `json:"password" valid:"-"`

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -29,6 +29,7 @@ type Profile struct {
 	DockerVersion   string      `json:"dockerVersion" valid:"-"`
 	K8SVersion      string      `json:"K8SVersion" valid:"-"`
 	K8SServicesCIDR string      `json:"k8sServicesCIDR" valid:"-"`
+	K8SAPIPort      int64       `json:"k8sApiPort" valid:"-"`
 	NetworkProvider string      `json:"networkProvider" valid:"-"`
 	FlannelVersion  string      `json:"flannelVersion" valid:"-"`
 	NetworkType     string      `json:"networkType" valid:"-"`
@@ -36,9 +37,9 @@ type Profile struct {
 	HelmVersion     string      `json:"helmVersion" valid:"-"`
 	RBACEnabled     bool        `json:"rbacEnabled" valid:"-"`
 	// This field is AWS specific, mapping AZ -> subnet
-	Subnets                map[string]string     `json:"subnets" valid:"-"`
-	CloudSpecificSettings  CloudSpecificSettings `json:"cloudSpecificSettings" valid:"-"`
-	PublicKey              string                `json:"publicKey" valid:"-"`
+	Subnets               map[string]string     `json:"subnets" valid:"-"`
+	CloudSpecificSettings CloudSpecificSettings `json:"cloudSpecificSettings" valid:"-"`
+	PublicKey             string                `json:"publicKey" valid:"-"`
 
 	// ExposedAddresses is a list of cidr/port pairs that will be exposes
 	// by cloud provider security groups.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -10,11 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/copycerts"
-
 	"github.com/supergiant/control/pkg/clouds"
-
 	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/pki"
 	"github.com/supergiant/control/pkg/profile"
@@ -27,6 +23,7 @@ import (
 	"github.com/supergiant/control/pkg/workflows/statuses"
 	"github.com/supergiant/control/pkg/workflows/steps"
 	"github.com/supergiant/control/pkg/workflows/steps/configmap"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/copycerts"
 )
 
 type KubeService interface {
@@ -753,6 +750,7 @@ func (tp *TaskProvisioner) buildInitialCluster(ctx context.Context,
 		SSHConfig: config.Kube.SSHConfig,
 
 		ExposedAddresses: config.Kube.ExposedAddresses,
+		APIServerPort:    config.Kube.APIServerPort,
 	}
 
 	return tp.kubeService.Create(ctx, cluster)

--- a/pkg/workflows/steps/amazon/create_load_balancer.go
+++ b/pkg/workflows/steps/amazon/create_load_balancer.go
@@ -2,6 +2,7 @@ package amazon
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/supergiant/control/pkg/util"
 	"github.com/supergiant/control/pkg/workflows/steps"
 )
@@ -81,8 +81,8 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, out io.Writer, cfg *st
 		output, err := svc.CreateLoadBalancerWithContext(ctx, &elb.CreateLoadBalancerInput{
 			Listeners: []*elb.Listener{
 				{
-					InstancePort:     aws.Int64(443),
-					LoadBalancerPort: aws.Int64(443),
+					InstancePort:     aws.Int64(cfg.Kube.APIServerPort),
+					LoadBalancerPort: aws.Int64(cfg.Kube.APIServerPort),
 					Protocol:         aws.String("TCP"),
 				},
 			},
@@ -126,8 +126,8 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, out io.Writer, cfg *st
 		output, err := svc.CreateLoadBalancerWithContext(ctx, &elb.CreateLoadBalancerInput{
 			Listeners: []*elb.Listener{
 				{
-					InstancePort:     aws.Int64(443),
-					LoadBalancerPort: aws.Int64(443),
+					InstancePort:     aws.Int64(cfg.Kube.APIServerPort),
+					LoadBalancerPort: aws.Int64(cfg.Kube.APIServerPort),
 					Protocol:         aws.String("TCP"),
 				},
 				{
@@ -206,7 +206,7 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, out io.Writer, cfg *st
 			UnhealthyThreshold: &unhealthyThreshold,
 			Interval:           &checkInternal,
 			Timeout:            &checkTimeout,
-			Target:             aws.String("HTTPS:443/healthz"),
+			Target:             aws.String(fmt.Sprintf("HTTPS:%d/healthz", cfg.Kube.APIServerPort)),
 		},
 	}
 
@@ -222,7 +222,7 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, out io.Writer, cfg *st
 			UnhealthyThreshold: &unhealthyThreshold,
 			Interval:           &checkInternal,
 			Timeout:            &checkTimeout,
-			Target:             aws.String("HTTPS:443/healthz"),
+			Target:             aws.String(fmt.Sprintf("HTTPS:%d/healthz", cfg.Kube.APIServerPort)),
 		},
 	}
 

--- a/pkg/workflows/steps/azure/create_nsg.go
+++ b/pkg/workflows/steps/azure/create_nsg.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
-
 	"github.com/supergiant/control/pkg/model"
 	"github.com/supergiant/control/pkg/sgerrors"
 	"github.com/supergiant/control/pkg/workflows/steps"
@@ -65,7 +64,7 @@ func (s *CreateSecurityGroupStep) Run(ctx context.Context, output io.Writer, con
 	}{
 		{
 			role:  model.RoleMaster.String(),
-			rules: masterSecurityRules(sgAddr),
+			rules: masterSecurityRules(sgAddr, config.Kube.APIServerPort),
 		},
 		{
 			role:  model.RoleNode.String(),
@@ -125,7 +124,7 @@ func (s *CreateSecurityGroupStep) Description() string {
 	return "Azure: Create master/node network security groups"
 }
 
-func masterSecurityRules(sgAddr string) []network.SecurityRule {
+func masterSecurityRules(sgAddr string, apiserverPort int64) []network.SecurityRule {
 	return []network.SecurityRule{
 		{
 			Name: to.StringPtr("allow_ssh_for_sg"),
@@ -147,7 +146,7 @@ func masterSecurityRules(sgAddr string) []network.SecurityRule {
 				SourceAddressPrefix:      to.StringPtr("0.0.0.0/0"),
 				SourcePortRange:          to.StringPtr("1-65535"),
 				DestinationAddressPrefix: to.StringPtr("0.0.0.0/0"),
-				DestinationPortRange:     to.StringPtr("443"),
+				DestinationPortRange:     to.StringPtr(fmt.Sprintf("%d", apiserverPort)),
 				Access:                   network.SecurityRuleAccessAllow,
 				Direction:                network.SecurityRuleDirectionInbound,
 				Priority:                 to.Int32Ptr(200),

--- a/pkg/workflows/steps/digitalocean/create_load_balancer.go
+++ b/pkg/workflows/steps/digitalocean/create_load_balancer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/supergiant/control/pkg/clouds/digitaloceansdk"
 	"github.com/supergiant/control/pkg/util"
 	"github.com/supergiant/control/pkg/workflows/steps"
@@ -41,9 +40,9 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, output io.Writer, conf
 		Region: config.DigitalOceanConfig.Region,
 		ForwardingRules: []godo.ForwardingRule{
 			{
-				EntryPort:      443,
+				EntryPort:      int(config.Kube.APIServerPort),
 				EntryProtocol:  "TCP",
-				TargetPort:     443,
+				TargetPort:     int(config.Kube.APIServerPort),
 				TargetProtocol: "TCP",
 			},
 			{
@@ -61,7 +60,7 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, output io.Writer, conf
 		},
 		HealthCheck: &godo.HealthCheck{
 			Protocol:               "TCP",
-			Port:                   443,
+			Port:                   int(config.Kube.APIServerPort),
 			CheckIntervalSeconds:   10,
 			UnhealthyThreshold:     3,
 			HealthyThreshold:       3,
@@ -114,11 +113,11 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, output io.Writer, conf
 		Region: config.DigitalOceanConfig.Region,
 		ForwardingRules: []godo.ForwardingRule{
 			{
-				EntryPort:      443,
+				EntryPort:      int(config.Kube.APIServerPort),
 				EntryProtocol:  "TCP",
-				TargetPort:     443,
+				TargetPort:     int(config.Kube.APIServerPort),
 				TargetProtocol: "TCP",
-				},
+			},
 			{
 				EntryPort:      2379,
 				EntryProtocol:  "TCP",
@@ -134,7 +133,7 @@ func (s *CreateLoadBalancerStep) Run(ctx context.Context, output io.Writer, conf
 		},
 		HealthCheck: &godo.HealthCheck{
 			Protocol:               "TCP",
-			Port:                   443,
+			Port:                   int(config.Kube.APIServerPort),
 			CheckIntervalSeconds:   10,
 			UnhealthyThreshold:     3,
 			HealthyThreshold:       3,

--- a/pkg/workflows/steps/gce/create_forwarding_rules.go
+++ b/pkg/workflows/steps/gce/create_forwarding_rules.go
@@ -6,12 +6,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"google.golang.org/api/compute/v1"
-
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/supergiant/control/pkg/clouds/gcesdk"
 	"github.com/supergiant/control/pkg/workflows/steps"
+	"google.golang.org/api/compute/v1"
 )
 
 const CreateForwardingRulesStepName = "gce_create_forwarding_rules"
@@ -103,7 +102,7 @@ func (s *CreateForwardingRules) Run(ctx context.Context, output io.Writer,
 		LoadBalancingScheme: "INTERNAL",
 		Description:         "Internal forwarding rule to target pool",
 		IPProtocol:          "TCP",
-		Ports:               []string{"443"},
+		Ports:               []string{fmt.Sprintf("%d", config.Kube.APIServerPort)},
 		BackendService:      config.GCEConfig.BackendServiceLink,
 		Network:             config.GCEConfig.NetworkLink,
 		Subnetwork:          config.GCEConfig.SubnetLink,

--- a/pkg/workflows/steps/gce/create_health_check.go
+++ b/pkg/workflows/steps/gce/create_health_check.go
@@ -2,15 +2,15 @@ package gce
 
 import (
 	"context"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/supergiant/control/pkg/clouds/gcesdk"
-	"google.golang.org/api/compute/v1"
+	"fmt"
 	"io"
 	"time"
 
-	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/supergiant/control/pkg/clouds/gcesdk"
 	"github.com/supergiant/control/pkg/workflows/steps"
+	"google.golang.org/api/compute/v1"
 )
 
 const CreateHealthCheckStepName = "gce_create_health_check"
@@ -58,7 +58,7 @@ func (s *CreateHealthCheck) Run(ctx context.Context, output io.Writer,
 		UnhealthyThreshold: 3,
 		Type:               "HTTPS",
 		HttpsHealthCheck: &compute.HTTPSHealthCheck{
-			Port: 443,
+			Port:        config.Kube.APIServerPort,
 			RequestPath: "/healthz",
 		},
 	}

--- a/pkg/workflows/steps/kubeadm/kubeadm.go
+++ b/pkg/workflows/steps/kubeadm/kubeadm.go
@@ -6,11 +6,9 @@ import (
 	"io"
 	"text/template"
 
-	"github.com/supergiant/control/pkg/clouds"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
+	"github.com/supergiant/control/pkg/clouds"
 	tm "github.com/supergiant/control/pkg/templatemanager"
 	"github.com/supergiant/control/pkg/workflows/steps"
 	"github.com/supergiant/control/pkg/workflows/steps/docker"
@@ -52,6 +50,7 @@ func (t *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	config.KubeadmConfig.NodeIp = config.Node.PrivateIp
 	config.KubeadmConfig.CACertHash = config.CertificatesConfig.CACertHash
 	config.KubeadmConfig.UserName = clouds.OSUser
+	config.KubeadmConfig.APIServerPort = config.Kube.APIServerPort
 
 	logrus.Debugf("kubeadm step: %s cluster: isBootstrap=%t extDNS=%s intDNS=%s",
 		config.ClusterID, config.KubeadmConfig.IsBootstrap, config.KubeadmConfig.ExternalDNSName,

--- a/pkg/workflows/steps/kubelet/kubelet.go
+++ b/pkg/workflows/steps/kubelet/kubelet.go
@@ -3,7 +3,6 @@ package kubelet
 import (
 	"context"
 	"fmt"
-	"github.com/supergiant/control/pkg/workflows/util"
 	"io"
 	"text/template"
 
@@ -11,6 +10,7 @@ import (
 	tm "github.com/supergiant/control/pkg/templatemanager"
 	"github.com/supergiant/control/pkg/workflows/steps"
 	"github.com/supergiant/control/pkg/workflows/steps/docker"
+	"github.com/supergiant/control/pkg/workflows/util"
 )
 
 const (
@@ -55,6 +55,7 @@ func (t *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	config.KubeletConfig.NodeName = config.Node.Name
 	config.KubeletConfig.IsMaster = config.IsMaster
 	config.KubeletConfig.UserName = config.Kube.SSHConfig.User
+	config.KubeletConfig.APIServerPort = config.Kube.APIServerPort
 
 	if len(config.KubeletConfig.ServicesCIDR) > 0 {
 		kubeDefaultSvcIp, err := util.GetKubernetesDefaultSvcIP(config.KubeletConfig.ServicesCIDR)

--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -1,25 +1,24 @@
 package workflows
 
 import (
-	"github.com/supergiant/control/pkg/workflows/steps/apply"
 	"sync"
-
-	"github.com/supergiant/control/pkg/workflows/steps/amazon"
-	"github.com/supergiant/control/pkg/workflows/steps/azure"
-	"github.com/supergiant/control/pkg/workflows/steps/digitalocean"
-	"github.com/supergiant/control/pkg/workflows/steps/gce"
 
 	"github.com/supergiant/control/pkg/workflows/statuses"
 	"github.com/supergiant/control/pkg/workflows/steps"
+	"github.com/supergiant/control/pkg/workflows/steps/amazon"
+	"github.com/supergiant/control/pkg/workflows/steps/apply"
 	"github.com/supergiant/control/pkg/workflows/steps/authorizedkeys"
+	"github.com/supergiant/control/pkg/workflows/steps/azure"
 	"github.com/supergiant/control/pkg/workflows/steps/bootstraptoken"
 	"github.com/supergiant/control/pkg/workflows/steps/certificates"
 	"github.com/supergiant/control/pkg/workflows/steps/clustercheck"
 	"github.com/supergiant/control/pkg/workflows/steps/configmap"
+	"github.com/supergiant/control/pkg/workflows/steps/digitalocean"
 	"github.com/supergiant/control/pkg/workflows/steps/docker"
 	"github.com/supergiant/control/pkg/workflows/steps/downloadk8sbinary"
 	"github.com/supergiant/control/pkg/workflows/steps/drain"
 	"github.com/supergiant/control/pkg/workflows/steps/evacuate"
+	"github.com/supergiant/control/pkg/workflows/steps/gce"
 	"github.com/supergiant/control/pkg/workflows/steps/kubeadm"
 	"github.com/supergiant/control/pkg/workflows/steps/kubelet"
 	"github.com/supergiant/control/pkg/workflows/steps/network"
@@ -109,9 +108,9 @@ func Init() {
 	azureInfra := []steps.Step{
 		steps.GetStep(azure.GetAuthorizerStepName),
 		steps.GetStep(azure.CreateGroupStepName),
-		steps.GetStep(azure.CreateLBStepName),
 		steps.GetStep(azure.CreateVNetAndSubnetsStepName),
 		steps.GetStep(azure.CreateSecurityGroupStepName),
+		steps.GetStep(azure.CreateLBStepName),
 	}
 
 	masterWorkflow := []steps.Step{

--- a/templates/kubeadm.go
+++ b/templates/kubeadm.go
@@ -32,7 +32,7 @@ sudo bash -c "cat << EOF > /etc/supergiant/kubeadm.conf
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 localAPIEndpoint:
-  bindPort: 443
+  bindPort: {{ .APIServerPort }}
 nodeRegistration:
   kubeletExtraArgs:
     node-ip: {{ .NodeIp }}
@@ -43,7 +43,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
 kubernetesVersion: v{{ .K8SVersion }}
 clusterName: kubernetes
-controlPlaneEndpoint: {{ .InternalDNSName }}:443
+controlPlaneEndpoint: {{ .InternalDNSName }}:{{ .APIServerPort }}
 certificatesDir: /etc/kubernetes/pki
 apiServer:
   certSANs:
@@ -83,18 +83,18 @@ nodeRegistration:
 discovery:
   bootstrapToken:
     token: {{ .Token }}
-    apiServerEndpoint: {{ .InternalDNSName }}:443
+    apiServerEndpoint: {{ .InternalDNSName }}:{{ .APIServerPort }}
     caCertHashes: [{{ .CACertHash }}]
 controlPlane:
   localAPIEndpoint:
-    bindPort: 443
+    bindPort: {{ .APIServerPort }}
   certificateKey: {{ .CertificateKey }}
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
 kubernetesVersion: v{{ .K8SVersion }}
 clusterName: kubernetes
-controlPlaneEndpoint: {{ .InternalDNSName }}:443
+controlPlaneEndpoint: {{ .InternalDNSName }}:{{ .APIServerPort }}
 certificatesDir: /etc/kubernetes/pki
 apiServer:
   certSANs:
@@ -119,7 +119,7 @@ networking:
 EOF"
 
 sudo kubeadm config images pull
-sudo kubeadm join --ignore-preflight-errors=NumCPU {{ .InternalDNSName }}:443 \
+sudo kubeadm join --ignore-preflight-errors=NumCPU {{ .InternalDNSName }}:{{ .APIServerPort }} \
 --node-name ${HOSTNAME} \
 --config=/etc/supergiant/kubeadm.conf
 {{ end }}
@@ -143,12 +143,12 @@ nodeRegistration:
 discovery:
   bootstrapToken:
     token: {{ .Token }}
-    apiServerEndpoint: {{ .InternalDNSName }}:443
+    apiServerEndpoint: {{ .InternalDNSName }}:{{ .APIServerPort }}
     caCertHashes:
     - {{ .CACertHash }}
 EOF"
 
-sudo kubeadm join --ignore-preflight-errors=NumCPU {{ .InternalDNSName }}:443 \
+sudo kubeadm join --ignore-preflight-errors=NumCPU {{ .InternalDNSName }}:{{ .APIServerPort }} \
 --node-name ${HOSTNAME} \
 --config=/etc/supergiant/kubeadm.conf
 {{ end }}

--- a/templates/kubelet.go
+++ b/templates/kubelet.go
@@ -35,7 +35,7 @@ sudo bash -c "cat > /etc/kubernetes/pki/admin.crt <<EOF
 sudo bash -c "cat > /etc/kubernetes/pki/admin.key <<EOF
 {{ .AdminKey }}EOF"
 
-sudo kubectl --kubeconfig=/home/{{ .UserName }}/.kube/config config set-cluster kubernetes --server='https://{{ .LoadBalancerHost }}' --certificate-authority=/etc/kubernetes/pki/ca.crt --embed-certs=true
+sudo kubectl --kubeconfig=/home/{{ .UserName }}/.kube/config config set-cluster kubernetes --server='https://{{ .LoadBalancerHost }}:{{ .APIServerPort }}'' --certificate-authority=/etc/kubernetes/pki/ca.crt --embed-certs=true
 sudo kubectl --kubeconfig=/home/{{ .UserName }}/.kube/config config set-credentials kubernetes --client-certificate=/etc/kubernetes/pki/admin.crt --client-key=/etc/kubernetes/pki/admin.key --embed-certs=true
 sudo kubectl --kubeconfig=/home/{{ .UserName }}/.kube/config config set-context kubernetes --cluster=kubernetes --user=kubernetes
 sudo kubectl --kubeconfig=/home/{{ .UserName }}/.kube/config config use-context kubernetes


### PR DESCRIPTION
<!--
(>^-^)> -* Thanks for contributing!! *- <(^-^<) 

Please see our guidelines: supergiant.readme.io/docs/guidelines
If you are confused by anything, please ask. We're here to help!
You can reach us at supergiantio.slack.com :]
-->

## Type

<!-- What types of changes does this PR introduce? -->
<!-- Put an `x` in all the boxes that apply to this PR. -->

- [ ] Fix (a **bug** or other **issue** was fixed)
- [ ] Feature (**new functionality** was added)
- [ ] Breaking (**existing functionality** was affected)
- [x] Other (please **explain** below)

<!-- If this PR has "breaking changes," specify details here. -->

## Details

<!-- Summarize the "what" and "why" of this PR. -->
<!-- This is important--it will be in the release notes. -->

By defualt, control uses 443 port to configure kube-apiserver. Introduce the `k8sApiPort` kube profile option to make it configurable.

## Checklist

<!-- Put an `x` in all the boxes that apply to this PR. -->
<!-- Please add documentation if this PR requires it. -->
<!-- (Hit "SUGGEST EDITS" on the page that needs changes.) -->

- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **needed**, and I updated it.
- [ ] [Documentation](https://supergiant.readme.io/v2.1.0-alpha/) was **not** needed.
- [x] I understand [the Contribution Guidelines](https://supergiant.readme.io/docs/guidelines).
